### PR TITLE
Replace custom bash validator with skill-validator

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -26,72 +26,36 @@ on:
 
 jobs:
   validate:
-    name: Validate SKILL.md files
+    name: Validate skills
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate skill frontmatter
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: false
+
+      - name: Install skill-validator
+        run: go install github.com/agent-ecosystem/skill-validator/cmd/skill-validator@latest
+
+      - name: Validate skills
         shell: bash
         run: |
           errors=0
 
-          # Find all SKILL.md files in the catalog
-          while IFS= read -r file; do
-            echo "Checking $file..."
-
-            # Check file has frontmatter delimiters
-            first_line=$(head -1 "$file")
-            if [[ "$first_line" != "---" ]]; then
-              echo "::error file=$file::Missing YAML frontmatter (file must start with ---)"
-              ((errors++))
-              continue
-            fi
-
-            # Extract frontmatter (between first and second ---)
-            frontmatter=$(sed -n '2,/^---$/p' "$file" | sed '$d')
-
-            if [[ -z "$frontmatter" ]]; then
-              echo "::error file=$file::Empty or malformed YAML frontmatter"
-              ((errors++))
-              continue
-            fi
-
-            # Check required fields
-            for field in name description version; do
-              value=$(echo "$frontmatter" | grep "^${field}:" | head -1 | sed "s/^${field}: *//")
-              if [[ -z "$value" ]]; then
-                echo "::error file=$file::Missing required field: $field"
-                ((errors++))
+          for dir in skills/*/*/; do
+            if ! skill-validator check --emit-annotations -o markdown "$dir" >> "$GITHUB_STEP_SUMMARY" 2>&1; then
+              exit_code=$?
+              # exit 1 = errors, exit 2 = warnings only
+              if [[ $exit_code -eq 1 ]]; then
+                errors=1
               fi
-            done
-
-            # Validate version is SemVer
-            version=$(echo "$frontmatter" | grep "^version:" | head -1 | sed "s/^version: *//")
-            if [[ -n "$version" ]] && ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-              echo "::error file=$file::Invalid version '$version' — must be SemVer (e.g., 1.0.0)"
-              ((errors++))
             fi
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          done
 
-            # Validate directory name matches skill name
-            skill_name=$(echo "$frontmatter" | grep "^name:" | head -1 | sed "s/^name: *//")
-            dir_name=$(basename "$(dirname "$file")")
-            if [[ -n "$skill_name" && "$skill_name" != "$dir_name" ]]; then
-              echo "::error file=$file::Skill name '$skill_name' does not match directory name '$dir_name'"
-              ((errors++))
-            fi
-
-            if [[ $errors -eq 0 ]]; then
-              echo "  ✓ Valid"
-            fi
-
-          done < <(find skills -name "SKILL.md" -type f 2>/dev/null | sort)
-
-          if [[ $errors -gt 0 ]]; then
-            echo ""
-            echo "Found $errors validation error(s)"
+          if [[ $errors -ne 0 ]]; then
+            echo "::error::Skill validation failed with errors"
             exit 1
           fi
-
-          echo ""
-          echo "All skills validated successfully"

--- a/README.md
+++ b/README.md
@@ -64,24 +64,30 @@ Bump the `version` field in your `SKILL.md` frontmatter when making changes.
 
 ## CI validation
 
-All PRs are validated by GitHub Actions (`.github/workflows/validate-skills.yml`):
+All PRs that touch `skills/**` are validated by GitHub Actions using [`skill-validator`](https://github.com/agent-ecosystem/skill-validator). The workflow (`.github/workflows/validate-skills.yml`) runs the following checks on every skill:
 
-- Every `skills/**/SKILL.md` must have valid YAML frontmatter
-- Required fields: `name`, `description`, `version`
-- `version` must be valid SemVer
-- Directory name must match the `name` field
+- **Structure** — `SKILL.md` exists with valid YAML frontmatter and required fields
+- **Links** — all external URLs resolve successfully
+- **Content analysis** — word density, code block ratios, instruction specificity
+- **Contamination detection** — flags cross-language code examples that could confuse LLMs
+
+Results are posted as inline annotations on the PR and rendered in the Actions step summary. Warnings are non-blocking; only errors fail the check.
 
 ## Repository structure
 
 ```
 elastic-docs-skills/
-├── .github/workflows/        # CI validation
-├── .claude/skills/            # Skills that work within this repo
-├── skills/                    # The browsable catalog
+├── .github/
+│   ├── copilot-setup-steps.yml   # GitHub Copilot coding agent setup
+│   └── workflows/
+│       ├── validate-skills.yml   # Skill validation via skill-validator
+│       └── skill-freshness.lock.yml
+├── .claude/skills/               # Skills that work within this repo
+├── skills/                       # The browsable catalog
 │   └── <category>/
 │       └── <skill-name>/
 │           └── SKILL.md
-├── install.sh                 # Interactive TUI installer
+├── install.sh                    # Interactive TUI installer
 └── README.md
 ```
 

--- a/skills/authoring/docs-syntax-help/SKILL.md
+++ b/skills/authoring/docs-syntax-help/SKILL.md
@@ -481,7 +481,11 @@ Included files must live in a `_snippets` folder:
 :::
 ```
 
-Link to anchors in included content: `[text](parent-file.md#anchor-from-snippet)`.
+Link to anchors in included content using the parent page path:
+
+```
+[Link text](parent-file.md#anchor-from-snippet)
+```
 
 ## CSV tables
 


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled bash frontmatter checker in the `validate-skills` workflow with [`skill-validator`](https://github.com/agent-ecosystem/skill-validator), which validates structure, links, content quality, and contamination
- Writes markdown results to `$GITHUB_STEP_SUMMARY` and emits inline `::error`/`::warning` annotations on files
- Treats warnings (exit 2) as non-blocking; only actual errors (exit 1) fail the job
- Fixes a broken internal link in `docs-syntax-help` (example link moved into a fenced code block)

## Test plan

- [ ] Verify the workflow runs on this PR and passes
- [ ] Check the step summary renders correctly in the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)