### PR TITLE
Integrate Skill Creator evaluation framework

### DIFF
--- a/.claude/skills/create-skill/SKILL.md
+++ b/.claude/skills/create-skill/SKILL.md
@@ -100,7 +100,28 @@ After writing the file:
 3. Do NOT move on until the user confirms they're happy with the result
 4. If the user requests changes, edit the file and present the updated version again
 
-### Step 5: Suggest testing and contributing
+### Step 5: Generate evals
+
+After the user approves the skill, generate 2-3 test cases as `evals/evals.json` inside the skill directory. Follow the schema in `references/eval-schemas.md`.
+
+Good evals:
+- Use realistic, substantive prompts (not "do X" — include file paths, context, specifics)
+- Have expectations that are discriminating (fail when the skill doesn't work, not just pass for any output)
+- Cover the core use case, an edge case, and a validation/error scenario
+- Test the skill's unique value-add, not things the base model already handles
+
+Present the evals to the user: "Here are the test cases I'd suggest. Do these look right, or do you want to add more?"
+
+### Step 6: Optimize the description (optional)
+
+After evals are written, offer to optimize the skill's `description` field for better triggering accuracy. The description is the primary mechanism that determines whether Claude invokes a skill.
+
+A good description:
+- States what the skill does AND specific contexts for when to use it
+- Is slightly "pushy" to combat under-triggering (Claude tends to not use skills even when they'd help)
+- Includes trigger words users would naturally say
+
+### Step 7: Suggest testing and contributing
 
 Once the user approves, suggest testing:
 - Running `./install.sh` to install it locally

--- a/.claude/skills/create-skill/agents/analyzer.md
+++ b/.claude/skills/create-skill/agents/analyzer.md
@@ -1,0 +1,73 @@
+# Post-hoc Analyzer Agent
+
+Analyze blind comparison results to understand WHY the winner won and generate improvement suggestions.
+
+## Role
+
+After the blind comparator determines a winner, examine the skills and transcripts to extract actionable insights.
+
+## Inputs
+
+- **winner**: "A" or "B" (from blind comparison)
+- **winner_skill_path**: Path to the winning skill
+- **winner_transcript_path**: Transcript for the winner
+- **loser_skill_path**: Path to the losing skill
+- **loser_transcript_path**: Transcript for the loser
+- **comparison_result_path**: Path to comparator output JSON
+- **output_path**: Where to save analysis
+
+## Process
+
+1. Read comparison result and understand what the comparator valued.
+2. Read both skills' SKILL.md files. Identify structural differences.
+3. Read both transcripts. Compare execution patterns.
+4. Evaluate instruction following (1-10 scale).
+5. Identify winner strengths and loser weaknesses.
+6. Generate prioritized improvement suggestions.
+
+## Output Format
+
+Save to `{output_path}`:
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner",
+    "loser_skill": "path/to/loser",
+    "comparator_reasoning": "Brief summary"
+  },
+  "winner_strengths": ["..."],
+  "loser_weaknesses": ["..."],
+  "instruction_following": {
+    "winner": { "score": 9, "issues": ["..."] },
+    "loser": { "score": 6, "issues": ["..."] }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions|tools|examples|error_handling|structure|references",
+      "suggestion": "Specific change to make",
+      "expected_impact": "What this would improve"
+    }
+  ]
+}
+```
+
+## Guidelines
+
+- **Be specific**: Quote from skills and transcripts
+- **Be actionable**: Suggestions should be concrete changes
+- **Prioritize by impact**: Which changes would have changed the outcome?
+- **Consider causation**: Did the weakness actually cause worse output?
+
+## Analyzing Benchmark Results
+
+When analyzing benchmarks (not comparisons), focus on surfacing patterns:
+
+- Assertions that always pass in both configurations (non-discriminating)
+- Assertions that always fail in both (beyond capability)
+- High-variance evals (flaky or non-deterministic)
+- Time/token tradeoffs
+
+Output as a JSON array of observation strings.

--- a/.claude/skills/create-skill/agents/comparator.md
+++ b/.claude/skills/create-skill/agents/comparator.md
@@ -1,0 +1,54 @@
+# Blind Comparator Agent
+
+Compare two outputs WITHOUT knowing which skill version produced them.
+
+## Role
+
+Judge which output better accomplishes the eval task. You receive two outputs labeled A and B. You do NOT know which skill produced which. This prevents bias.
+
+## Inputs
+
+- **output_a_path**: Path to the first output
+- **output_b_path**: Path to the second output
+- **eval_prompt**: The original task/prompt
+- **expectations**: List of expectations to check (optional)
+
+## Process
+
+1. Examine both outputs thoroughly.
+2. Understand the task requirements from the eval prompt.
+3. Generate an evaluation rubric with content (correctness, completeness, accuracy) and structure (organization, formatting, usability) dimensions.
+4. Score each output 1-5 on each criterion.
+5. If expectations provided, check each against both outputs.
+6. Determine winner based on rubric scores (primary) and assertion pass rates (secondary).
+
+## Output Format
+
+Save to the specified path as JSON:
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Clear explanation of why",
+  "rubric": {
+    "A": {
+      "content": { "correctness": 5, "completeness": 5, "accuracy": 4 },
+      "structure": { "organization": 4, "formatting": 5, "usability": 4 },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": { "...same structure..." }
+  },
+  "output_quality": {
+    "A": { "score": 9, "strengths": ["..."], "weaknesses": ["..."] },
+    "B": { "score": 5, "strengths": ["..."], "weaknesses": ["..."] }
+  }
+}
+```
+
+## Guidelines
+
+- **Stay blind**: Do NOT infer which skill produced which output
+- **Be decisive**: Ties should be rare
+- **Be specific**: Cite examples when explaining strengths/weaknesses

--- a/.claude/skills/create-skill/agents/grader.md
+++ b/.claude/skills/create-skill/agents/grader.md
@@ -1,0 +1,66 @@
+# Grader Agent
+
+Evaluate expectations against an execution transcript and outputs.
+
+## Role
+
+The Grader reviews a transcript and output files, then determines whether each expectation passes or fails. Provide clear evidence for each judgment.
+
+You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak assertion is worse than useless — it creates false confidence.
+
+## Inputs
+
+- **expectations**: List of expectations to evaluate (strings)
+- **transcript_path**: Path to the execution transcript
+- **outputs_dir**: Directory containing output files from execution
+
+## Process
+
+1. Read the transcript file completely. Note the eval prompt, execution steps, and final result.
+2. Examine output files in outputs_dir relevant to the expectations.
+3. For each expectation:
+   - Search for evidence in the transcript and outputs
+   - **PASS**: Clear evidence the expectation is true AND reflects genuine task completion
+   - **FAIL**: No evidence, contradicted, or superficial compliance
+   - Cite specific evidence
+4. Extract and verify implicit claims from outputs (factual, process, quality).
+5. If `{outputs_dir}/user_notes.md` exists, read and incorporate concerns.
+6. Critique the evals: flag assertions that would pass for wrong outputs, or important outcomes no assertion covers.
+
+## Output Format
+
+Save to `{outputs_dir}/../grading.json`:
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The expectation text",
+      "passed": true,
+      "evidence": "Specific quote or description"
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The assertion in question",
+        "reason": "Why it could be improved"
+      }
+    ],
+    "overall": "Brief assessment of eval quality"
+  }
+}
+```
+
+## Guidelines
+
+- **Be objective**: Base verdicts on evidence, not assumptions
+- **Be specific**: Quote the exact text that supports your verdict
+- **No partial credit**: Each expectation is pass or fail
+- **PASS burden**: The evidence must demonstrate genuine task completion, not surface compliance

--- a/.claude/skills/create-skill/references/eval-schemas.md
+++ b/.claude/skills/create-skill/references/eval-schemas.md
@@ -1,0 +1,72 @@
+# Eval Schemas
+
+JSON schemas used by the skill evaluation system.
+
+## evals.json
+
+Located at `<skill-dir>/evals/evals.json`.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's example prompt",
+      "expected_output": "Description of expected result",
+      "files": ["evals/files/sample.txt"],
+      "expectations": [
+        "The output includes X",
+        "The skill used Y approach"
+      ]
+    }
+  ]
+}
+```
+
+**Fields:**
+- `skill_name`: Must match the skill's frontmatter `name`
+- `evals[].id`: Unique integer
+- `evals[].prompt`: Realistic user prompt (substantive, not trivial)
+- `evals[].expected_output`: Human-readable success description
+- `evals[].files`: Optional input files (relative to skill root)
+- `evals[].expectations`: Verifiable assertions for automated grading
+
+## grading.json
+
+Output from the grader agent.
+
+```json
+{
+  "expectations": [
+    { "text": "assertion text", "passed": true, "evidence": "specific quote" }
+  ],
+  "summary": { "passed": 2, "failed": 1, "total": 3, "pass_rate": 0.67 },
+  "eval_feedback": {
+    "suggestions": [{ "assertion": "...", "reason": "..." }],
+    "overall": "Brief assessment"
+  }
+}
+```
+
+## comparison.json
+
+Output from blind comparator.
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Why the winner was chosen",
+  "rubric": {
+    "A": { "content_score": 4.7, "structure_score": 4.3, "overall_score": 9.0 },
+    "B": { "content_score": 2.7, "structure_score": 2.7, "overall_score": 5.4 }
+  }
+}
+```
+
+## Writing Good Evals
+
+- **Prompts should be realistic**: Include file paths, personal context, specifics. Not abstract requests.
+- **Expectations should be discriminating**: They should fail when the skill doesn't work, not just pass for any output.
+- **2-3 evals per skill minimum**: Cover the core use case, an edge case, and a validation/error case.
+- **Focus on what matters**: Test the skill's unique value-add, not things the base model already handles.

--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -4,6 +4,11 @@
       "repo": "github/gh-aw/actions/setup",
       "version": "v0.49.4",
       "sha": "bf34f9947505c887fdc597a13b8ff277cccd9c20"
+    },
+    "github/gh-aw/actions/setup@v0.53.3": {
+      "repo": "github/gh-aw/actions/setup",
+      "version": "v0.53.3",
+      "sha": "a0ed2f46906483dcf634e8694268e4fab9b21e65"
     }
   }
 }

--- a/.github/workflows/skill-eval-test.lock.yml
+++ b/.github/workflows/skill-eval-test.lock.yml
@@ -21,36 +21,42 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Weekly check of all skills for staleness against their upstream source URLs.
-# Compares each SKILL.md against the documentation it encodes and opens a PR
-# if anything has drifted.
+# Run eval test cases against skills changed in a PR. For each changed skill
+# that has evals/evals.json, execute the test prompts with the skill and grade
+# the outputs against expectations. Posts results as a PR comment.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"1613965c5c46b7a523fa0109c2680aab83802f159a2f3b391c891c9ac832454e","compiler_version":"v0.53.3"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"811d052fb6505ec5927524fb5ddc4d0ee63bf9c314d70401980eeb056d115439","compiler_version":"v0.53.3"}
 
-name: "Weekly Skill Freshness Check"
+name: "Skill Eval Testing"
 "on":
-  schedule:
-  - cron: "21 6 * * 0"
-    # Friendly format: weekly (scattered)
-  workflow_dispatch:
+  pull_request:
+    paths:
+    - skills/**
 
 permissions: {}
 
 concurrency:
-  group: "gh-aw-${{ github.workflow }}"
+  group: "gh-aw-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}"
+  cancel-in-progress: true
 
-run-name: "Weekly Skill Freshness Check"
+run-name: "Skill Eval Testing"
 
 jobs:
   activation:
+    needs: pre_activation
+    if: >
+      (needs.pre_activation.outputs.activated == 'true') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
     permissions:
       contents: read
     outputs:
+      body: ${{ steps.sanitized.outputs.body }}
       comment_id: ""
       comment_repo: ""
       model: ${{ steps.generate_aw_info.outputs.model }}
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
+      text: ${{ steps.sanitized.outputs.text }}
+      title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
         uses: github/gh-aw/actions/setup@a0ed2f46906483dcf634e8694268e4fab9b21e65 # v0.53.3
@@ -65,7 +71,7 @@ jobs:
           GH_AW_INFO_VERSION: ""
           GH_AW_INFO_AGENT_VERSION: "0.0.421"
           GH_AW_INFO_CLI_VERSION: "v0.53.3"
-          GH_AW_INFO_WORKFLOW_NAME: "Weekly Skill Freshness Check"
+          GH_AW_INFO_WORKFLOW_NAME: "Skill Eval Testing"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -96,12 +102,21 @@ jobs:
       - name: Check workflow file timestamps
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          GH_AW_WORKFLOW_FILE: "skill-freshness.lock.yml"
+          GH_AW_WORKFLOW_FILE: "skill-eval-test.lock.yml"
         with:
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/check_workflow_timestamp_api.cjs');
+            await main();
+      - name: Compute current body text
+        id: sanitized
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io);
+            const { main } = require('/opt/gh-aw/actions/compute_text.cjs');
             await main();
       - name: Create prompt with built-in context
         env:
@@ -127,10 +142,7 @@ jobs:
           cat "/opt/gh-aw/prompts/safe_outputs_prompt.md"
           cat << 'GH_AW_PROMPT_EOF'
           <safe-output-tools>
-          Tools: add_comment, close_issue, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_EOF
-          cat "/opt/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_EOF'
+          Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -165,7 +177,7 @@ jobs:
           </system>
           GH_AW_PROMPT_EOF
           cat << 'GH_AW_PROMPT_EOF'
-          {{#runtime-import .github/workflows/skill-freshness.md}}
+          {{#runtime-import .github/workflows/skill-eval-test.md}}
           GH_AW_PROMPT_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
@@ -190,6 +202,7 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
@@ -208,7 +221,8 @@ jobs:
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
-                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE
+                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
               }
             });
       - name: Validate prompt placeholders
@@ -236,8 +250,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    concurrency:
-      group: "gh-aw-copilot-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -247,7 +259,7 @@ jobs:
       GH_AW_SAFE_OUTPUTS: /opt/gh-aw/safeoutputs/outputs.jsonl
       GH_AW_SAFE_OUTPUTS_CONFIG_PATH: /opt/gh-aw/safeoutputs/config.json
       GH_AW_SAFE_OUTPUTS_TOOLS_PATH: /opt/gh-aw/safeoutputs/tools.json
-      GH_AW_WORKFLOW_ID_SANITIZED: skillfreshness
+      GH_AW_WORKFLOW_ID_SANITIZED: skillevaltest
     outputs:
       checkout_pr_success: ${{ steps.checkout-pr.outputs.checkout_pr_success || 'true' }}
       detection_conclusion: ${{ steps.detection_conclusion.outputs.conclusion }}
@@ -306,42 +318,10 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > /opt/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"add_comment":{"max":1},"close_issue":{"max":1},"create_pull_request":{"max":1,"title_prefix":"[skill-freshness] "},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
+          {"add_comment":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
-            {
-              "description": "Close a GitHub issue with a closing comment. You can and should always add a comment when closing an issue to explain the action or provide context. This tool is ONLY for closing issues - use update_issue if you need to change the title, body, labels, or other metadata without closing. Use close_issue when work is complete, the issue is no longer relevant, or it's a duplicate. The closing comment should explain the resolution or reason for closing. If the issue is already closed, a comment will still be posted. CONSTRAINTS: Maximum 1 issue(s) can be closed.",
-              "inputSchema": {
-                "additionalProperties": false,
-                "properties": {
-                  "body": {
-                    "description": "Closing comment explaining why the issue is being closed and summarizing any resolution, workaround, or conclusion.",
-                    "type": "string"
-                  },
-                  "integrity": {
-                    "description": "Trustworthiness level of the message source (e.g., \"low\", \"medium\", \"high\").",
-                    "type": "string"
-                  },
-                  "issue_number": {
-                    "description": "Issue number to close. This is the numeric ID from the GitHub URL (e.g., 901 in github.com/owner/repo/issues/901). If omitted, closes the issue that triggered this workflow (requires an issue event trigger).",
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "secrecy": {
-                    "description": "Confidentiality level of the message content (e.g., \"public\", \"internal\", \"private\").",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "body"
-                ],
-                "type": "object"
-              },
-              "name": "close_issue"
-            },
             {
               "description": "Add a comment to an existing GitHub issue, pull request, or discussion. Use this to provide feedback, answer questions, or add information to an existing conversation. For creating new items, use create_issue, create_discussion, or create_pull_request instead. IMPORTANT: Comments are subject to validation constraints enforced by the MCP server - maximum 65536 characters for the complete comment (including footer which is added automatically), 10 mentions (@username), and 50 links. Exceeding these limits will result in an immediate error with specific guidance. NOTE: By default, this tool requires discussions:write permission. If your GitHub App lacks Discussions permission, set 'discussions: false' in the workflow's safe-outputs.add-comment configuration to exclude this permission. CONSTRAINTS: Maximum 1 comment(s) can be added.",
               "inputSchema": {
@@ -370,55 +350,6 @@ jobs:
                 "type": "object"
               },
               "name": "add_comment"
-            },
-            {
-              "description": "Create a new GitHub pull request to propose code changes. Use this after making file edits to submit them for review and merging. The PR will be created from the current branch with your committed changes. For code review comments on an existing PR, use create_pull_request_review_comment instead. CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[skill-freshness] \". Labels [\"automated\" \"skill-freshness\"] will be automatically added.",
-              "inputSchema": {
-                "additionalProperties": false,
-                "properties": {
-                  "body": {
-                    "description": "Detailed PR description in Markdown. Include what changes were made, why, testing notes, and any breaking changes. Do NOT repeat the title as a heading.",
-                    "type": "string"
-                  },
-                  "branch": {
-                    "description": "Source branch name containing the changes. If omitted, uses the current working branch.",
-                    "type": "string"
-                  },
-                  "draft": {
-                    "description": "Whether to create the PR as a draft. Draft PRs cannot be merged until marked as ready for review. Use mark_pull_request_as_ready_for_review to convert a draft PR. Default: true.",
-                    "type": "boolean"
-                  },
-                  "integrity": {
-                    "description": "Trustworthiness level of the message source (e.g., \"low\", \"medium\", \"high\").",
-                    "type": "string"
-                  },
-                  "labels": {
-                    "description": "Labels to categorize the PR (e.g., 'enhancement', 'bugfix'). Labels must exist in the repository.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "repo": {
-                    "description": "Target repository in 'owner/repo' format. For multi-repo workflows where the target repo differs from the workflow repo, this must match a repo in the allowed-repos list or the configured target-repo. If omitted, defaults to the configured target-repo (from safe-outputs config), NOT the workflow repository. In most cases, you should omit this parameter and let the system use the configured default.",
-                    "type": "string"
-                  },
-                  "secrecy": {
-                    "description": "Confidentiality level of the message content (e.g., \"public\", \"internal\", \"private\").",
-                    "type": "string"
-                  },
-                  "title": {
-                    "description": "Concise PR title describing the changes. Follow repository conventions (e.g., conventional commits). The title appears as the main heading.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "title",
-                  "body"
-                ],
-                "type": "object"
-              },
-              "name": "create_pull_request"
             },
             {
               "description": "Report that a tool or capability needed to complete the task is not available, or share any information you deem important about missing functionality or limitations. Use this when you cannot accomplish what was requested because the required functionality is missing or access is restricted.",
@@ -532,60 +463,6 @@ jobs:
                 "repo": {
                   "type": "string",
                   "maxLength": 256
-                }
-              }
-            },
-            "close_issue": {
-              "defaultMax": 1,
-              "fields": {
-                "body": {
-                  "required": true,
-                  "type": "string",
-                  "sanitize": true,
-                  "maxLength": 65000
-                },
-                "issue_number": {
-                  "optionalPositiveInteger": true
-                },
-                "repo": {
-                  "type": "string",
-                  "maxLength": 256
-                }
-              }
-            },
-            "create_pull_request": {
-              "defaultMax": 1,
-              "fields": {
-                "body": {
-                  "required": true,
-                  "type": "string",
-                  "sanitize": true,
-                  "maxLength": 65000
-                },
-                "branch": {
-                  "required": true,
-                  "type": "string",
-                  "sanitize": true,
-                  "maxLength": 256
-                },
-                "draft": {
-                  "type": "boolean"
-                },
-                "labels": {
-                  "type": "array",
-                  "itemType": "string",
-                  "itemSanitize": true,
-                  "itemMaxLength": 128
-                },
-                "repo": {
-                  "type": "string",
-                  "maxLength": 256
-                },
-                "title": {
-                  "required": true,
-                  "type": "string",
-                  "sanitize": true,
-                  "maxLength": 128
                 }
               }
             },
@@ -913,7 +790,6 @@ jobs:
             /tmp/gh-aw/sandbox/firewall/logs/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
-            /tmp/gh-aw/aw-*.patch
           if-no-files-found: ignore
       # --- Threat Detection (inline) ---
       - name: Check if detection needed
@@ -951,8 +827,8 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          WORKFLOW_NAME: "Weekly Skill Freshness Check"
-          WORKFLOW_DESCRIPTION: "Weekly check of all skills for staleness against their upstream source URLs.\nCompares each SKILL.md against the documentation it encodes and opens a PR\nif anything has drifted."
+          WORKFLOW_NAME: "Skill Eval Testing"
+          WORKFLOW_DESCRIPTION: "Run eval test cases against skills changed in a PR. For each changed skill\nthat has evals/evals.json, execute the test prompts with the skill and grade\nthe outputs against expectations. Posts results as a PR comment."
           HAS_PATCH: ${{ steps.collect_output.outputs.has_patch }}
         with:
           script: |
@@ -1040,12 +916,12 @@ jobs:
     if: (always()) && (needs.agent.result != 'skipped')
     runs-on: ubuntu-slim
     permissions:
-      contents: write
+      contents: read
       discussions: write
       issues: write
       pull-requests: write
     concurrency:
-      group: "gh-aw-conclusion-skill-freshness"
+      group: "gh-aw-conclusion-skill-eval-test"
       cancel-in-progress: false
     outputs:
       noop_message: ${{ steps.noop.outputs.noop_message }}
@@ -1075,7 +951,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Weekly Skill Freshness Check"
+          GH_AW_WORKFLOW_NAME: "Skill Eval Testing"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1088,7 +964,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Weekly Skill Freshness Check"
+          GH_AW_WORKFLOW_NAME: "Skill Eval Testing"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1101,15 +977,13 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Weekly Skill Freshness Check"
+          GH_AW_WORKFLOW_NAME: "Skill Eval Testing"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_WORKFLOW_ID: "skill-freshness"
+          GH_AW_WORKFLOW_ID: "skill-eval-test"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
           GH_AW_INFERENCE_ACCESS_ERROR: ${{ needs.agent.outputs.inference_access_error }}
-          GH_AW_CODE_PUSH_FAILURE_ERRORS: ${{ needs.safe_outputs.outputs.code_push_failure_errors }}
-          GH_AW_CODE_PUSH_FAILURE_COUNT: ${{ needs.safe_outputs.outputs.code_push_failure_count }}
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_TIMEOUT_MINUTES: "20"
         with:
@@ -1124,7 +998,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Weekly Skill Freshness Check"
+          GH_AW_WORKFLOW_NAME: "Skill Eval Testing"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
@@ -1136,38 +1010,46 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/handle_noop_message.cjs');
             await main();
-      - name: Handle Create Pull Request Error
-        id: handle_create_pr_error
+
+  pre_activation:
+    if: (github.event_name != 'pull_request') || (github.event.pull_request.head.repo.id == github.repository_id)
+    runs-on: ubuntu-slim
+    outputs:
+      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
+      matched_command: ''
+    steps:
+      - name: Setup Scripts
+        uses: github/gh-aw/actions/setup@a0ed2f46906483dcf634e8694268e4fab9b21e65 # v0.53.3
+        with:
+          destination: /opt/gh-aw/actions
+      - name: Check team membership for workflow
+        id: check_membership
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Weekly Skill Freshness Check"
-          GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_AW_REQUIRED_ROLES: admin,maintainer,write
         with:
-          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { setupGlobals } = require('/opt/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io);
-            const { main } = require('/opt/gh-aw/actions/handle_create_pr_error.cjs');
+            const { main } = require('/opt/gh-aw/actions/check_membership.cjs');
             await main();
 
   safe_outputs:
-    needs:
-      - activation
-      - agent
+    needs: agent
     if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (needs.agent.outputs.detection_success == 'true')
     runs-on: ubuntu-slim
     permissions:
-      contents: write
+      contents: read
       discussions: write
       issues: write
       pull-requests: write
     timeout-minutes: 15
     env:
-      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/skill-freshness"
+      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/skill-eval-test"
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_WORKFLOW_ID: "skill-freshness"
-      GH_AW_WORKFLOW_NAME: "Weekly Skill Freshness Check"
+      GH_AW_WORKFLOW_ID: "skill-eval-test"
+      GH_AW_WORKFLOW_NAME: "Skill Eval Testing"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
@@ -1175,8 +1057,6 @@ jobs:
       comment_url: ${{ steps.process_safe_outputs.outputs.comment_url }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
-      created_pr_number: ${{ steps.process_safe_outputs.outputs.created_pr_number }}
-      created_pr_url: ${{ steps.process_safe_outputs.outputs.created_pr_url }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
@@ -1197,34 +1077,6 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs/
           find "/tmp/gh-aw/safeoutputs/" -type f -print
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/safeoutputs/agent_output.json" >> "$GITHUB_ENV"
-      - name: Download patch artifact
-        continue-on-error: true
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-        with:
-          name: agent-artifacts
-          path: /tmp/gh-aw/
-      - name: Checkout repository
-        if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.base_ref || github.event.pull_request.base.ref || github.ref_name || github.event.repository.default_branch }}
-          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          persist-credentials: false
-          fetch-depth: 1
-      - name: Configure Git credentials
-        if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
-        env:
-          REPO_NAME: ${{ github.repository }}
-          SERVER_URL: ${{ github.server_url }}
-          GIT_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git config --global am.keepcr true
-          # Re-authenticate git with GitHub token
-          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
-          git remote set-url origin "https://x-access-token:${GIT_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
-          echo "Git configured with standard GitHub Actions identity"
       - name: Process Safe Outputs
         id: process_safe_outputs
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -1233,8 +1085,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs-v3-preview.elastic.dev,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.elastic.co"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"close_issue\":{\"max\":1},\"create_pull_request\":{\"labels\":[\"automated\",\"skill-freshness\"],\"max\":1,\"max_patch_size\":1024,\"title_prefix\":\"[skill-freshness] \"},\"missing_data\":{},\"missing_tool\":{}}"
-          GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/skill-eval-test.md
+++ b/.github/workflows/skill-eval-test.md
@@ -1,0 +1,122 @@
+---
+description: |
+  Run eval test cases against skills changed in a PR. For each changed skill
+  that has evals/evals.json, execute the test prompts with the skill and grade
+  the outputs against expectations. Posts results as a PR comment.
+
+on:
+  pull_request:
+    paths: ['skills/**']
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+network:
+  allowed:
+    - defaults
+    - "www.elastic.co"
+    - "docs-v3-preview.elastic.dev"
+
+tools:
+  github:
+    lockdown: false
+  web-fetch:
+  edit:
+
+safe-outputs:
+  add-comment:
+---
+<!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+or more contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright
+ownership. Elasticsearch B.V. licenses this file to you under
+the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. -->
+
+# Skill Eval Testing
+
+Run eval test cases against skills changed in this PR and report results.
+
+## Process
+
+1. List files changed in this PR. Identify skills that were modified (any file under `skills/<category>/<skill-name>/`).
+2. For each changed skill, check if `evals/evals.json` exists in the skill directory.
+3. If evals exist, run the evaluation process below. If no evals exist, note it and skip.
+4. Post a single comment on the PR with all results.
+
+## Running evals
+
+For each eval in `evals/evals.json`:
+
+### Step 1: Read the skill
+
+Read the skill's `SKILL.md` file completely. This is the skill you're testing.
+
+### Step 2: Execute the eval prompt
+
+Follow the skill's instructions to accomplish the eval prompt. Act as if you are a Claude Code agent with the skill loaded. Do your best to complete the task described in the prompt.
+
+Save your output (the response you would give the user) to a workspace directory.
+
+### Step 3: Grade against expectations
+
+After completing the task, evaluate your own output against each expectation in the eval:
+
+- **PASS**: Your output clearly satisfies the expectation with specific evidence
+- **FAIL**: Your output does not satisfy the expectation, or you can't find evidence
+
+Be honest and strict. The purpose is to catch regressions, not to rubber-stamp.
+
+### Step 4: Compile results
+
+For each eval, record:
+- The prompt (truncated to first 100 chars)
+- Pass/fail for each expectation
+- Overall pass rate
+- Any notable observations
+
+## Comment format
+
+Post a single comment with this structure:
+
+```
+## Skill Eval Results
+
+### <skill-name>
+
+| Eval | Prompt | Pass Rate | Details |
+|------|--------|-----------|---------|
+| 1 | <first 80 chars of prompt>... | 3/4 (75%) | ❌ expectation that failed |
+| 2 | <first 80 chars of prompt>... | 4/4 (100%) | All passed |
+
+**Overall**: X/Y expectations passed (Z%)
+
+<Brief assessment of skill quality based on eval results>
+```
+
+If a skill has no evals:
+
+```
+### <skill-name>
+
+⚠️ No evals found. Consider adding `evals/evals.json` with test cases.
+```
+
+## Important notes
+
+- This is an advisory check — it does not block the PR.
+- Focus on whether the skill's instructions lead to correct behavior, not on cosmetic issues.
+- If an eval requires external resources (files, APIs) that aren't available, note it as "skipped — requires external resource" rather than failing.
+- Do not modify any files in the repository.

--- a/.github/workflows/skill-freshness.md
+++ b/.github/workflows/skill-freshness.md
@@ -62,5 +62,32 @@ Check all skills in `skills/**/SKILL.md` for staleness against their upstream so
    - When fetching a source URL, always append `.md` to the URL (e.g. `https://www.elastic.co/docs/contribute-docs/style-guide` becomes `https://www.elastic.co/docs/contribute-docs/style-guide.md`). The `.md` variant returns an LLM-friendly markdown version of the page.
    - Compare the fetched content against the rules, syntax, and options encoded in the skill.
    - If the skill is stale (new rules added, syntax changed, options removed, links broken), update the SKILL.md to reflect the current upstream state.
-3. If any files changed, open a pull request summarizing what drifted and why.
+   - After updating a skill, run its evals to catch regressions (see "Post-update eval check" below).
+3. If any files changed, open a pull request summarizing what drifted, why, and eval results.
 4. If nothing changed, close this issue with a comment confirming all skills are current.
+
+## Post-update eval check
+
+After updating a skill, check whether `evals/evals.json` exists in the skill directory. If it does:
+
+1. **Before editing**, read the original SKILL.md content and save it mentally as the "old version."
+2. **After editing**, for each eval in `evals/evals.json`:
+   - Read the eval prompt and expectations.
+   - Follow the **updated** skill's instructions to accomplish the eval prompt.
+   - Grade your output against each expectation (PASS/FAIL with evidence).
+3. **Compare**: Note any expectations that the updated skill fails. If the update causes regressions (expectations that would have passed with the old version now fail), flag these in the PR body.
+4. **Include results** in the PR body under a "### Eval results" section for each updated skill:
+
+```markdown
+### Eval results
+
+#### <skill-name>
+| Eval | Pass Rate | Regressions |
+|------|-----------|-------------|
+| 1 — <prompt summary> | 3/4 (75%) | None |
+| 2 — <prompt summary> | 2/3 (67%) | ❌ "expectation text" — was passing before update |
+```
+
+If all evals pass, note "All evals passing" instead of the table.
+
+If no evals exist for a skill, note "No evals available" and skip.

--- a/skills/authoring/applies-to-tagging/evals/evals.json
+++ b/skills/authoring/applies-to-tagging/evals/evals.json
@@ -1,0 +1,37 @@
+{
+  "skill_name": "applies-to-tagging",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I just added a new page about machine learning anomaly detection that's available in both stack (since 8.15) and serverless elasticsearch. Can you add the right applies_to frontmatter?",
+      "expected_output": "Correct YAML frontmatter with applies_to containing stack: ga 8.15 and serverless with elasticsearch subkey set to ga",
+      "expectations": [
+        "The output includes applies_to in YAML frontmatter format",
+        "stack is set to ga with version 8.15",
+        "serverless uses the elasticsearch subkey set to ga",
+        "No mixed dimensions are used (stack/serverless only)"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Can you check the applies_to tags in this file? The frontmatter says:\n---\napplies_to:\n  stack: ga 9.2, ga 9.3\n  serverless: ga\n  deployment:\n    ess: ga\n---",
+      "expected_output": "Report identifying two validation errors: duplicate lifecycle for same key (ga 9.2, ga 9.3) and mixed dimensions (stack/serverless mixed with deployment)",
+      "expectations": [
+        "Flags the duplicate ga lifecycle as invalid (one version per lifecycle rule)",
+        "Flags mixed dimensions (stack/serverless cannot be combined with deployment at page level)",
+        "Does not flag serverless: ga as an error"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I need to mark a section as unavailable in serverless but keep it for stack. It's a heading called '## Node-to-node encryption'. What's the right syntax?",
+      "expected_output": "Section-level applies_to annotation using backtick-fenced block placed after the heading, with serverless: unavailable",
+      "expectations": [
+        "Uses backtick-fenced applies_to block (not colon-fenced)",
+        "Places the block after the heading, not inline with it",
+        "Sets serverless to unavailable",
+        "Does not remove or modify the heading itself"
+      ]
+    }
+  ]
+}

--- a/skills/authoring/content-type-checker/evals/evals.json
+++ b/skills/authoring/content-type-checker/evals/evals.json
@@ -1,0 +1,27 @@
+{
+  "skill_name": "content-type-checker",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Check this page against the content type guidelines. It's a how-to guide but it starts with a long explanation of what Elasticsearch indices are, has no numbered steps, and the title is 'Elasticsearch Index Management Overview'.",
+      "expected_output": "Report identifying content type mismatch (title says overview but claimed how-to), missing step-by-step instructions, and excessive conceptual content for a how-to",
+      "expectations": [
+        "Identifies the title pattern as inconsistent with how-to type",
+        "Flags the lack of numbered/step-by-step instructions",
+        "Notes that conceptual explanations belong in an overview, not a how-to",
+        "Produces a structured report with required elements and best practices sections"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I wrote a troubleshooting page for common Kibana dashboard errors. Can you check if it follows the right structure? The file is at docs/troubleshooting/kibana-dashboards.md",
+      "expected_output": "Evaluation against troubleshooting content type guidelines, checking for problem/cause/solution structure, symptoms, and prerequisites",
+      "expectations": [
+        "Attempts to read the file or asks for its content",
+        "References the troubleshooting content type guidelines",
+        "Checks for problem-cause-solution structure",
+        "Generates a report with required elements checklist"
+      ]
+    }
+  ]
+}

--- a/skills/authoring/docs-redirects/evals/evals.json
+++ b/skills/authoring/docs-redirects/evals/evals.json
@@ -1,0 +1,27 @@
+{
+  "skill_name": "docs-redirects",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I'm moving security/authentication.md to security/user-auth/overview.md. The old page had anchors #saml and #oidc that now live on separate pages security/user-auth/saml.md and security/user-auth/oidc.md. Can you set up the redirects?",
+      "expected_output": "A complex redirect entry in redirects.yml using the 'many' form with anchor-level routing to different target pages",
+      "expectations": [
+        "Creates a redirect from security/authentication.md to security/user-auth/overview.md as the default target",
+        "Maps #saml anchor to security/user-auth/saml.md",
+        "Maps #oidc anchor to security/user-auth/oidc.md",
+        "Uses the many form for multi-target anchor routing",
+        "Uses single quotes around YAML paths"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "We deleted the page getting-started/quick-start.md and the content now lives in the docs-content repo at get-started/quickstart.md. Add a redirect.",
+      "expected_output": "A cross-repository redirect using the repo:// syntax",
+      "expectations": [
+        "Uses cross-repository syntax (docs-content://get-started/quickstart.md or similar)",
+        "Adds the entry under the redirects: key in redirects.yml",
+        "Mentions searching for internal links to the old path that need updating"
+      ]
+    }
+  ]
+}

--- a/skills/authoring/docs-syntax-help/evals/evals.json
+++ b/skills/authoring/docs-syntax-help/evals/evals.json
@@ -1,0 +1,38 @@
+{
+  "skill_name": "docs-syntax-help",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I'm trying to nest a code block inside a note inside a tab, and the build keeps failing. Here's what I have:\n\n:::{tab-set}\n:::{tab-item} Example\n:::{note}\n```yaml\nkey: value\n```\n:::\n:::\n:::",
+      "expected_output": "Identifies the colon count mismatch in nested directives and provides corrected syntax with proper nesting levels",
+      "expectations": [
+        "Identifies that the outer tab-set needs more colons than tab-item, which needs more than note",
+        "Provides corrected syntax with 4+ colons for tab-set, 3+ for tab-item, 3 for note",
+        "Explains that code blocks inside directives use backtick fences",
+        "The corrected example would actually build successfully"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "How do I create synced tabs where Java and Python tabs switch together across the whole page?",
+      "expected_output": "Shows tab-set with :group: and tab-item with :sync: options, explaining that matching group+sync values synchronize across tab sets",
+      "expectations": [
+        "Uses the :group: option on tab-set",
+        "Uses the :sync: option on each tab-item",
+        "Shows a complete, valid tab-set example",
+        "Explains that matching group and sync values cause synchronization"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I need to add explicit callouts to a YAML code block but I keep getting a build error about mismatched callout counts",
+      "expected_output": "Explains the <N> marker syntax and the rule that the numbered list count must exactly match the marker count",
+      "expectations": [
+        "Shows the <N> marker syntax at line ends in code blocks",
+        "Shows the matching numbered list after the code block",
+        "States that the marker count must exactly equal the list item count",
+        "Provides a working example"
+      ]
+    }
+  ]
+}

--- a/skills/review/crosslink-validator/evals/evals.json
+++ b/skills/review/crosslink-validator/evals/evals.json
@@ -1,0 +1,28 @@
+{
+  "skill_name": "crosslink-validator",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Check the cross-links in this file. It has these links:\n- [Kibana dashboards](kibana://dashboards/overview.md)\n- [Getting started](docs-content://get-started/intro.md)\n- [External docs](https://elastic.co/guide)\n- [Relative page](../setup.md)",
+      "expected_output": "Identifies the two cross-links (kibana:// and docs-content://), skips the https:// and relative links, and attempts to resolve each cross-link",
+      "expectations": [
+        "Identifies kibana://dashboards/overview.md as a cross-link to validate",
+        "Identifies docs-content://get-started/intro.md as a cross-link to validate",
+        "Skips the https:// URL (not a cross-link)",
+        "Skips the relative ../setup.md link (not a cross-link)",
+        "Attempts to resolve each cross-link via MCP or WebFetch fallback"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Validate all cross-links in the docs/security/ directory of our repo",
+      "expected_output": "Uses Grep to find cross-link patterns in the directory, then resolves each one and produces a structured report",
+      "expectations": [
+        "Uses Grep or Glob to scan the directory for cross-link patterns",
+        "Produces a report with summary counts (found, valid, broken)",
+        "Groups results by file",
+        "Reports file path and line number for any broken links"
+      ]
+    }
+  ]
+}

--- a/skills/review/docs-check-style/evals/evals.json
+++ b/skills/review/docs-check-style/evals/evals.json
@@ -1,0 +1,32 @@
+{
+  "skill_name": "docs-check-style",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Check this paragraph for style issues:\n\n\"Please click the button below to launch the application. The user will be able to easily configure their settings. We will provide you with the necessary information, e.g. API keys, which can be utilized to execute the relevant queries.\"",
+      "expected_output": "Flags multiple style violations: please, click, below, launch, easily, e.g., will, utilized, execute",
+      "expectations": [
+        "Flags 'please' as unnecessary per style guide",
+        "Flags 'below' as a positional reference (accessibility issue)",
+        "Flags 'launch' and suggests 'open'",
+        "Flags 'easily' as adding no value",
+        "Flags 'e.g.' and suggests 'for example'",
+        "Flags 'utilized' and suggests 'use'",
+        "Flags 'execute' and suggests 'run'",
+        "Categorizes issues by area (Word Choice, Voice/Tone, Accessibility)"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Review this heading and procedure for style:\n\n## How To Setup The Elasticsearch Cluster\n1. First, type your cluster name in the Name field\n2. Choose a region from the dropdown\n3. Click the Save button",
+      "expected_output": "Flags capitalization issues in heading, 'type' should be 'enter', 'choose' should be 'select', 'click the Save button' should be 'click Save'",
+      "expectations": [
+        "Flags heading capitalization (should be sentence-style, not title case)",
+        "Flags 'Setup' should be 'Set Up' (verb form) or suggests 'Set up'",
+        "Flags 'type' and suggests 'enter'",
+        "Flags 'Choose' and suggests 'Select'",
+        "Flags 'Click the Save button' and suggests 'Click **Save**' (no 'button' after label)"
+      ]
+    }
+  ]
+}

--- a/skills/workflow/docs-retro/evals/evals.json
+++ b/skills/workflow/docs-retro/evals/evals.json
@@ -1,0 +1,30 @@
+{
+  "skill_name": "docs-retro",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Run a retro on the current session",
+      "expected_output": "A structured retrospective report analyzing the current conversation with sections for docs opportunities, skill usage analysis, missing skills, and action items",
+      "expectations": [
+        "Produces a report with an executive summary",
+        "Includes a docs opportunities section (or states none identified)",
+        "Includes a skill usage analysis table",
+        "Includes a missing skills section (or states none identified)",
+        "Includes actionable items as a checklist",
+        "Does not modify any files"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Analyze the session transcript at ~/.claude/projects/my-project/abc123.jsonl and tell me what skills were used and what's missing",
+      "expected_output": "Attempts to locate and read the JSONL transcript, then produces a focused report on skill usage and missing skills",
+      "expectations": [
+        "Attempts to read the specified JSONL file",
+        "Parses conversation turns from the transcript",
+        "Reports which skills were invoked and their outcomes",
+        "Identifies workflows that lacked skill support",
+        "Proposes names and descriptions for missing skills"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Integrates evaluation testing from the [Skill Creator](https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills) methodology into the skills catalog. Five changes:

### 1. Evals for all existing skills
Each of the 7 skills now has `evals/evals.json` with 2-3 test cases covering core use cases, edge cases, and validation scenarios. These follow the Skill Creator schema (`prompt`, `expected_output`, `expectations`).

### 2. Skill Creator as a dev dependency
Bundled grader, comparator, and analyzer agent instructions into `.claude/skills/create-skill/agents/` plus an `eval-schemas.md` reference. These support local eval workflows without requiring a separate clone of the Skill Creator repo.

### 3. `/create-skill` generates evals
Updated the skill creation flow with two new steps:
- **Step 5**: Generate `evals/evals.json` with test cases after the skill is approved
- **Step 6**: Offer description optimization for better triggering accuracy

### 4. Eval testing gh-aw workflow
New `skill-eval-test.md` workflow triggers on PRs that touch `skills/**`. For each changed skill with evals, it executes the test prompts, grades outputs against expectations, and posts an advisory comment with pass rates.

### 5. A/B regression detection in freshness workflow
Extended `skill-freshness.md` with a post-update eval check. When the weekly freshness run updates a skill, it runs the skill's evals against both the old and new versions to catch regressions before opening a PR.

## Test plan

- [ ] Verify `evals/evals.json` files are valid JSON with correct schema
- [ ] Confirm `skill-eval-test` gh-aw workflow compiles and triggers on this PR
- [ ] Check that `/create-skill` prompts for evals after skill approval
- [ ] Verify freshness workflow still compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)