### PR TITLE
Improve repo quality and maintainability

### DIFF
--- a/.github/agents/docs-freshness-checker.agent.md
+++ b/.github/agents/docs-freshness-checker.agent.md
@@ -22,45 +22,33 @@ under the License. -->
 
 You are a freshness checker for the elastic-docs-skills catalog. Your job is to compare each skill file against its upstream source URLs and update skills that have drifted.
 
-## Finding skills
+## Finding skills and their sources
 
 Skill files live at `skills/**/SKILL.md`. Each skill has a YAML frontmatter block and a Markdown body encoding rules, syntax, or workflows derived from upstream Elastic documentation.
 
-## Source URLs per skill
+Source URLs are declared in each skill's YAML frontmatter under the `sources:` field:
 
-### applies-to-tagging (`skills/authoring/applies-to-tagging/SKILL.md`)
+```yaml
+---
+name: my-skill
+sources:
+  - https://www.elastic.co/docs/some-page
+  - https://docs-v3-preview.elastic.dev/some/other/page
+---
+```
 
-- [Syntax reference](https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/applies)
-- [Full key reference](https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/reference)
-- [Guidelines](https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/guidelines)
-- [Badge placement](https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/badge-placement)
-- [Example scenarios](https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/example-scenarios)
+To find all skills and their sources:
 
-### docs-syntax-help (`skills/authoring/docs-syntax-help/SKILL.md`)
-
-- [Syntax quick reference](https://www.elastic.co/docs/contribute-docs/syntax-quick-reference)
-- [Detailed syntax guide](https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax)
-
-### docs-check-style (`skills/review/docs-check-style/SKILL.md`)
-
-- [Style guide overview](https://www.elastic.co/docs/contribute-docs/style-guide)
-- [Voice and tone](https://www.elastic.co/docs/contribute-docs/style-guide/voice-tone)
-- [Accessibility](https://www.elastic.co/docs/contribute-docs/style-guide/accessibility)
-- [Grammar and spelling](https://www.elastic.co/docs/contribute-docs/style-guide/grammar-spelling)
-- [Word choice](https://www.elastic.co/docs/contribute-docs/style-guide/word-choice)
-- [Formatting](https://www.elastic.co/docs/contribute-docs/style-guide/formatting)
-- [UI writing](https://www.elastic.co/docs/contribute-docs/style-guide/ui-writing)
-
-### docs-retro (`skills/workflow/docs-retro/SKILL.md`)
-
-No upstream source URLs. This is an analysis skill, not reference-based. Skip during freshness checks.
+1. Find every `SKILL.md` file under the `skills/` directory.
+2. Parse the YAML frontmatter of each file.
+3. Read the `sources:` list. If a skill has no `sources:` field, skip it during freshness checks.
 
 ## How to check freshness
 
 For each skill that has source URLs:
 
 1. **Read** the SKILL.md file completely
-2. **Fetch** each source URL listed above
+2. **Fetch** each source URL (append `.md` to the URL for LLM-friendly versions)
 3. **Compare** the fetched content against what the skill encodes:
    - Are all rules from the upstream source present in the skill?
    - Has any syntax changed (new options, renamed directives, changed defaults)?
@@ -75,8 +63,8 @@ For each skill that has source URLs:
 
 When meaningful drift is found:
 
-1. **Preserve** the YAML frontmatter exactly (name, version, description, context, allowed-tools)
-2. **Bump** the version patch number (e.g., 1.0.0 → 1.0.1)
+1. **Preserve** the YAML frontmatter exactly (name, version, description, context, allowed-tools, sources)
+2. **Bump** the version patch number (e.g., 1.0.0 -> 1.0.1)
 3. **Edit** the Markdown body to reflect the upstream changes:
    - Add new rules or syntax patterns
    - Update changed syntax or options
@@ -92,10 +80,7 @@ If any skills were updated, open a PR with this body format:
 ## Skill freshness update — YYYY-MM-DD
 
 ### Skills checked
-- applies-to-tagging: [stale/current]
-- docs-syntax-help: [stale/current]
-- docs-check-style: [stale/current]
-- docs-retro: skipped (no upstream sources)
+- skill-name: [stale/current/skipped (no sources)]
 
 ### Changes made
 
@@ -115,8 +100,6 @@ If all skills are current, close the issue with a comment:
 ```
 All skills checked against upstream sources — no meaningful drift detected.
 
-- applies-to-tagging: current
-- docs-syntax-help: current
-- docs-check-style: current
-- docs-retro: skipped (no upstream sources)
+- skill-name: current
+- skill-name: skipped (no sources)
 ```

--- a/.github/workflows/check-aw-updates.yml
+++ b/.github/workflows/check-aw-updates.yml
@@ -1,0 +1,84 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Check gh-aw Updates
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Weekly on Mondays at 9am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-updates:
+    name: Check for gh-aw updates and recompile lock files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install gh-aw
+        run: gh extension install github/gh-aw
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save current lock file checksums
+        run: |
+          sha256sum .github/workflows/*.lock.yml > /tmp/lock-checksums-before.txt 2>/dev/null || true
+
+      - name: Recompile lock files
+        run: |
+          for md_file in .github/workflows/*.md; do
+            [ -f "$md_file" ] || continue
+            lock_file="${md_file%.md}.lock.yml"
+            [ -f "$lock_file" ] || continue
+            echo "Compiling $md_file..."
+            gh aw compile "$md_file" || echo "Warning: failed to compile $md_file"
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for changes
+        id: changes
+        run: |
+          sha256sum .github/workflows/*.lock.yml > /tmp/lock-checksums-after.txt 2>/dev/null || true
+          if diff -q /tmp/lock-checksums-before.txt /tmp/lock-checksums-after.txt > /dev/null 2>&1; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          branch="automated/gh-aw-update-$(date +%Y%m%d)"
+          git checkout -b "$branch"
+          git add .github/workflows/*.lock.yml .github/aw/actions-lock.json
+          git commit -m "Update gh-aw lock files
+
+          Automated recompilation of gh-aw workflow lock files."
+          git push -u origin "$branch"
+          gh pr create \
+            --title "Update gh-aw lock files" \
+            --body "Automated weekly check detected updated gh-aw lock files after recompilation.
+
+          Review the lock file diffs to verify the changes are expected." \
+            --label "automated"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/skill-freshness.md
+++ b/.github/workflows/skill-freshness.md
@@ -58,7 +58,7 @@ Check all skills in `skills/**/SKILL.md` for staleness against their upstream so
 1. Find every `SKILL.md` file under the `skills/` directory.
 2. For each skill:
    - Read the SKILL.md file.
-   - Identify every source URL in its reference/sources section.
+   - Parse the `sources:` list from its YAML frontmatter. If no `sources:` field exists, skip this skill.
    - When fetching a source URL, always append `.md` to the URL (e.g. `https://www.elastic.co/docs/contribute-docs/style-guide` becomes `https://www.elastic.co/docs/contribute-docs/style-guide.md`). The `.md` variant returns an LLM-friendly markdown version of the page.
    - Compare the fetched content against the rules, syntax, and options encoded in the skill.
    - If the skill is stale (new rules added, syntax changed, options removed, links broken), update the SKILL.md to reflect the current upstream state.

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -87,6 +87,45 @@ jobs:
 
           done < <(find skills -name "SKILL.md" -type f 2>/dev/null | sort)
 
+          # Validate eval files
+          while IFS= read -r eval_file; do
+            echo "Checking $eval_file..."
+
+            # Validate JSON syntax
+            if ! python3 -m json.tool "$eval_file" > /dev/null 2>&1; then
+              echo "::error file=$eval_file::Invalid JSON"
+              ((errors++))
+              continue
+            fi
+
+            # Validate required structure
+            valid=$(python3 -c "
+          import json, sys
+          with open('$eval_file') as f:
+              data = json.load(f)
+          if 'evals' not in data:
+              print('missing_evals'); sys.exit()
+          for i, e in enumerate(data['evals']):
+              for field in ['id', 'prompt', 'expectations']:
+                  if field not in e:
+                      print(f'eval[{i}]_missing_{field}'); sys.exit()
+              if not isinstance(e['expectations'], list) or len(e['expectations']) == 0:
+                  print(f'eval[{i}]_empty_expectations'); sys.exit()
+          print('ok')
+          " 2>&1)
+
+            if [[ "$valid" == "ok" ]]; then
+              echo "  ✓ Valid"
+            elif [[ "$valid" == "missing_evals" ]]; then
+              echo "::error file=$eval_file::Missing required 'evals' array"
+              ((errors++))
+            else
+              echo "::error file=$eval_file::Invalid eval structure: $valid"
+              ((errors++))
+            fi
+
+          done < <(find skills -name "evals.json" -type f 2>/dev/null | sort)
+
           if [[ $errors -gt 0 ]]; then
             echo ""
             echo "Found $errors validation error(s)"
@@ -94,4 +133,4 @@ jobs:
           fi
 
           echo ""
-          echo "All skills validated successfully"
+          echo "All skills and evals validated successfully"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# Elastic Docs Skills — Project Guide
+
+## What this repo is
+
+A catalog of Claude Code skills for Elastic documentation workflows. Skills are installed into `~/.claude/skills/` via `install.sh` and used as slash commands or auto-triggered behaviors in Claude Code.
+
+## Repository layout
+
+```
+skills/<category>/<skill-name>/
+  SKILL.md          # The skill definition (frontmatter + instructions)
+  evals/evals.json  # Test cases for the skill (optional but encouraged)
+.claude/skills/     # Skills that work within this repo only (e.g., /create-skill)
+.github/workflows/  # CI and gh-aw agentic workflows
+.github/agents/     # Copilot agent definitions
+```
+
+## Skill anatomy
+
+Every `skills/**/SKILL.md` must have YAML frontmatter:
+
+```yaml
+---
+name: my-skill              # Required — kebab-case, must match directory name
+version: 1.0.0              # Required — SemVer
+description: What it does    # Required — when to trigger this skill
+argument-hint: <args>        # Shown in autocomplete if skill accepts input
+disable-model-invocation: true  # Only via /my-skill, not auto-triggered
+context: fork                # Run in isolated subagent
+allowed-tools: Read, Grep    # Tools available without user approval
+sources:                     # Upstream URLs this skill encodes (for freshness checks)
+  - https://www.elastic.co/docs/some-page
+---
+```
+
+## Categories
+
+- **authoring** — Skills that help write or edit documentation content
+- **review** — Skills that validate, lint, or check existing content
+- **workflow** — Skills for meta-tasks (retros, session analysis, project management)
+
+## Conventions
+
+- Skill names are kebab-case and must match their directory name
+- Version follows SemVer: bump PATCH for fixes, MINOR for new features, MAJOR for breaking changes
+- Skills that only read/analyze should use `context: fork`
+- Skills that modify files should NOT use `context: fork`
+- All skills that accept `$ARGUMENTS` should have `argument-hint`
+- Skills derived from upstream docs should list URLs in `sources:` frontmatter
+
+## gh-aw workflows
+
+Agentic workflows use `.md` files compiled to `.lock.yml` via `gh aw compile`. The lock files are auto-generated — never edit them directly. The `.gitattributes` file marks them as `linguist-generated=true merge=ours`.
+
+## Adding a skill
+
+Use `/create-skill` within this repo, or see `CONTRIBUTING.md` for manual instructions.
+
+## Running CI locally
+
+```bash
+# Validate all skills
+find skills -name "SKILL.md" -type f -exec echo "Checking {}" \;
+
+# Validate eval JSON
+find skills -name "evals.json" -exec python3 -m json.tool {} \;
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,154 @@
+<!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+or more contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright
+ownership. Elasticsearch B.V. licenses this file to you under
+the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. -->
+
+# Contributing to Elastic Docs Skills
+
+## Quick start
+
+The fastest way to add a skill is to use the built-in command within this repo:
+
+```
+/create-skill my-new-skill
+```
+
+This walks you through the process interactively and can open a PR for you.
+
+## Manual creation
+
+### 1. Choose a category
+
+| Category | Purpose | Examples |
+|----------|---------|---------|
+| `authoring` | Help write or edit documentation content | syntax help, redirects, tagging |
+| `review` | Validate, lint, or check existing content | style checks, link validation |
+| `workflow` | Meta-tasks and process automation | retros, session analysis |
+
+If your skill doesn't fit an existing category, propose a new one in your PR description.
+
+### 2. Create the skill directory
+
+```
+skills/<category>/<skill-name>/
+  SKILL.md
+```
+
+The directory name must be kebab-case and will become the skill's name.
+
+### 3. Write the SKILL.md
+
+Every skill needs YAML frontmatter followed by markdown instructions.
+
+#### Required frontmatter
+
+```yaml
+---
+name: my-skill
+version: 1.0.0
+description: One-line description of what the skill does and when to trigger it.
+---
+```
+
+#### Optional frontmatter
+
+```yaml
+argument-hint: <file-or-directory>    # Autocomplete hint (add if skill accepts input)
+disable-model-invocation: true        # Only runs via /my-skill, not auto-triggered
+context: fork                         # Run in isolated subagent (use for read-only skills)
+allowed-tools: Read, Grep, Glob       # Tools available without asking for permission
+sources:                              # Upstream URLs this skill encodes
+  - https://www.elastic.co/docs/...
+```
+
+#### Frontmatter guidelines
+
+- **`context: fork`**: Use for skills that only read and report (style checks, validators, retros). Do NOT use for skills that edit files.
+- **`allowed-tools`**: List only the tools the skill actually needs. Include `Edit` or `Write` only if the skill modifies files.
+- **`sources`**: List every upstream documentation URL that the skill's rules are derived from. The weekly freshness checker uses these to detect drift.
+- **`argument-hint`**: Add this whenever the skill accepts `$ARGUMENTS`. Use angle brackets for placeholders: `<file-or-directory>`.
+- **`disable-model-invocation`**: Use for skills that should only run when explicitly invoked via `/skill-name`, not auto-triggered by Claude's judgment.
+
+#### Markdown body
+
+The body is the system prompt that drives the skill. Write it as instructions to Claude:
+
+- Start with "You are a..." role statement
+- Define inputs (`$ARGUMENTS`)
+- Describe the step-by-step process
+- Include examples and edge cases
+- End with reference URLs (if the skill is derived from upstream docs)
+
+### 4. Add evals (recommended)
+
+Create `evals/evals.json` in your skill directory:
+
+```json
+{
+  "skill_name": "my-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "A realistic user prompt that exercises the skill",
+      "expected_output": "Brief description of correct output",
+      "expectations": [
+        "Specific, testable assertion about the output",
+        "Another assertion"
+      ]
+    }
+  ]
+}
+```
+
+#### Eval guidelines
+
+- Write 3-5 evals covering common use cases and edge cases
+- Each eval needs an `id`, `prompt`, and `expectations` array
+- Expectations should be specific and independently verifiable
+- `expected_output` is a human-readable summary; `expectations` are the grading criteria
+- Evals run automatically on PRs that modify skills (via the `skill-eval-test` workflow)
+
+### 5. Open a PR
+
+CI will validate:
+
+- SKILL.md has valid YAML frontmatter with required fields
+- `name` matches the directory name
+- `version` is valid SemVer
+- `evals.json` (if present) has valid structure
+
+## Versioning
+
+Follow SemVer when editing existing skills:
+
+- **PATCH** (1.0.0 -> 1.0.1): Bug fixes, wording improvements, updated URLs
+- **MINOR** (1.0.0 -> 1.1.0): New capabilities, additional rules covered
+- **MAJOR** (1.0.0 -> 2.0.0): Breaking changes to behavior, output format, or interface
+
+## Avoiding contradictions
+
+Before writing a new skill, check existing skills for overlapping scope:
+
+- Read all skills in the same category
+- Search for keywords from your skill's domain across all SKILL.md files
+- If two skills could give conflicting advice, either merge them or clearly delineate their scopes in the descriptions
+
+## gh-aw workflows
+
+Agentic workflows live as `.md` files in `.github/workflows/`. They are compiled to `.lock.yml` files via `gh aw compile`. Rules:
+
+- Edit the `.md` file, never the `.lock.yml`
+- Run `gh aw compile .github/workflows/my-workflow.md` to regenerate the lock file
+- Commit both the `.md` and `.lock.yml` together

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ argument-hint: [args]            # Hint shown in autocomplete
 allowed-tools: Read, Grep        # Tools the skill can use without asking
 context: fork                    # Run in isolated subagent
 agent: Explore                   # Subagent type
+sources:                         # Upstream URLs for freshness checks
+  - https://www.elastic.co/docs/...
 ```
 
 ## Versioning
@@ -62,6 +64,14 @@ Skills follow [SemVer](https://semver.org/):
 
 Bump the `version` field in your `SKILL.md` frontmatter when making changes.
 
+## Updating installed skills
+
+```bash
+./install.sh --update
+```
+
+This compares your installed skill versions against the catalog and updates any that have newer versions available.
+
 ## CI validation
 
 All PRs are validated by GitHub Actions (`.github/workflows/validate-skills.yml`):
@@ -70,6 +80,7 @@ All PRs are validated by GitHub Actions (`.github/workflows/validate-skills.yml`
 - Required fields: `name`, `description`, `version`
 - `version` must be valid SemVer
 - Directory name must match the `name` field
+- `evals/evals.json` (if present) must be valid JSON with required structure
 
 ## Repository structure
 
@@ -87,10 +98,7 @@ elastic-docs-skills/
 
 ## Contributing
 
-1. Fork and clone this repository
-2. Create a skill using `/create-skill` or manually
-3. Ensure your `SKILL.md` has all required frontmatter fields
-4. Open a PR — CI will validate your skill automatically
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on creating skills, writing evals, choosing categories, and frontmatter conventions.
 
 ## License
 

--- a/install.sh
+++ b/install.sh
@@ -69,6 +69,7 @@ Requires Python 3 (ships with macOS and most Linux distributions).
 Options:
   --list            List all available skills and exit
   --all             Install all skills (non-interactive)
+  --update          Update all installed skills to latest versions
   --uninstall NAME  Remove an installed skill
   --help            Show this help message
 
@@ -219,6 +220,57 @@ cmd_install_all() {
   ok "Installed $count skill(s) to $INSTALL_DIR"
 }
 
+cmd_update() {
+  local catalog
+  catalog="$(build_catalog)"
+  [[ -z "$catalog" ]] && { err "No skills found in catalog"; exit 1; }
+  mkdir -p "$INSTALL_DIR"
+
+  local updated=0 skipped=0 total=0
+
+  for installed_dir in "$INSTALL_DIR"/*/; do
+    [[ ! -d "$installed_dir" ]] && continue
+    local skill_name
+    skill_name="$(basename "$installed_dir")"
+    [[ ! -f "$installed_dir/SKILL.md" ]] && continue
+
+    ((total++))
+
+    local installed_version
+    installed_version="$(parse_field "$installed_dir/SKILL.md" "version")"
+    [[ -z "$installed_version" ]] && installed_version="0.0.0"
+
+    local found=false
+    while IFS=$'\t' read -r name version category description path; do
+      if [[ "$name" == "$skill_name" ]]; then
+        found=true
+        if [[ "$version" == "$installed_version" ]]; then
+          ((skipped++))
+        else
+          install_one "$name" "$path" "$version"
+          info "  Updated from v$installed_version"
+          ((updated++))
+        fi
+        break
+      fi
+    done <<< "$catalog"
+
+    if [[ "$found" == false ]]; then
+      warn "Skill '$skill_name' is installed but not found in the catalog"
+      ((skipped++))
+    fi
+  done
+
+  echo ""
+  if [[ $total -eq 0 ]]; then
+    warn "No skills are currently installed at $INSTALL_DIR"
+  elif [[ $updated -eq 0 ]]; then
+    ok "All $total installed skill(s) are up to date"
+  else
+    ok "Updated $updated skill(s), $skipped already up to date"
+  fi
+}
+
 cmd_interactive() {
   # Check Python 3 is available
   local python_cmd=""
@@ -324,6 +376,9 @@ main() {
       ;;
     --list)
       cmd_list
+      ;;
+    --update)
+      cmd_update
       ;;
     --all)
       cmd_install_all

--- a/skills/authoring/applies-to-tagging/SKILL.md
+++ b/skills/authoring/applies-to-tagging/SKILL.md
@@ -2,8 +2,15 @@
 name: applies-to-tagging
 version: 1.0.0
 description: Validate and generate applies_to tags in Elastic documentation. Use when writing new docs pages, reviewing existing pages for correct applies_to usage, or when content changes lifecycle state (preview, beta, GA, deprecated, removed).
+argument-hint: <file-or-directory>
 context: fork
 allowed-tools: Read, Grep, Glob, Edit
+sources:
+  - https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/applies
+  - https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/reference
+  - https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/guidelines
+  - https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/badge-placement
+  - https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/example-scenarios
 ---
 <!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 or more contributor license agreements. See the NOTICE file distributed with

--- a/skills/authoring/content-type-checker/SKILL.md
+++ b/skills/authoring/content-type-checker/SKILL.md
@@ -2,8 +2,15 @@
 name: content-type-checker
 version: 2.0.0
 description: Check a docs-content page against Elastic content type guidelines (overview, how-to, tutorial, troubleshooting, changelog). Use when the user asks to check content type compliance, validate page structure, or review a doc against content type standards.
+argument-hint: <file-or-directory>
 context: fork
 allowed-tools: Read, Grep, Glob, CallMcpTool, WebFetch
+sources:
+  - https://www.elastic.co/docs/contribute-docs/content-types/overviews
+  - https://www.elastic.co/docs/contribute-docs/content-types/how-tos
+  - https://www.elastic.co/docs/contribute-docs/content-types/tutorials
+  - https://www.elastic.co/docs/contribute-docs/content-types/troubleshooting
+  - https://www.elastic.co/docs/contribute-docs/content-types/changelogs
 ---
 <!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 or more contributor license agreements. See the NOTICE file distributed with

--- a/skills/authoring/docs-redirects/SKILL.md
+++ b/skills/authoring/docs-redirects/SKILL.md
@@ -2,7 +2,10 @@
 name: docs-redirects
 version: 1.0.0
 description: Create and manage redirects in Elastic documentation when pages are moved, renamed, or deleted. Use when moving docs pages, renaming files, restructuring content, or when the user asks about redirects.
+argument-hint: <old-path> <new-path>
 allowed-tools: Read, Grep, Glob, Edit, Write
+sources:
+  - https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/redirects
 ---
 <!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 or more contributor license agreements. See the NOTICE file distributed with

--- a/skills/authoring/docs-syntax-help/SKILL.md
+++ b/skills/authoring/docs-syntax-help/SKILL.md
@@ -2,7 +2,11 @@
 name: docs-syntax-help
 version: 1.0.0
 description: Provide Elastic Docs syntax guidance, troubleshoot markup issues, and help write directives correctly. Use when writing or editing documentation that uses MyST Markdown with Elastic extensions, or when troubleshooting build errors related to syntax.
+argument-hint: <question-or-directive>
 allowed-tools: Read, Grep, Glob, Edit, WebFetch
+sources:
+  - https://www.elastic.co/docs/contribute-docs/syntax-quick-reference
+  - https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax
 ---
 <!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 or more contributor license agreements. See the NOTICE file distributed with

--- a/skills/review/crosslink-validator/SKILL.md
+++ b/skills/review/crosslink-validator/SKILL.md
@@ -2,6 +2,7 @@
 name: crosslink-validator
 version: 2.0.0
 description: Validate all cross-links in an Elastic documentation markdown file by extracting them and resolving each one. Use when the user asks to check, validate, or verify links in a documentation page, or mentions broken links.
+argument-hint: <file-or-directory>
 context: fork
 allowed-tools: Read, Grep, Glob, CallMcpTool, WebFetch
 ---

--- a/skills/review/docs-check-style/SKILL.md
+++ b/skills/review/docs-check-style/SKILL.md
@@ -5,6 +5,14 @@ description: Check documentation for Elastic style guide compliance using Vale l
 argument-hint: <file-or-directory>
 context: fork
 allowed-tools: Read, Grep, Glob, Bash(vale *), WebFetch
+sources:
+  - https://www.elastic.co/docs/contribute-docs/style-guide
+  - https://www.elastic.co/docs/contribute-docs/style-guide/voice-tone
+  - https://www.elastic.co/docs/contribute-docs/style-guide/accessibility
+  - https://www.elastic.co/docs/contribute-docs/style-guide/grammar-spelling
+  - https://www.elastic.co/docs/contribute-docs/style-guide/word-choice
+  - https://www.elastic.co/docs/contribute-docs/style-guide/formatting
+  - https://www.elastic.co/docs/contribute-docs/style-guide/ui-writing
 ---
 <!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 or more contributor license agreements. See the NOTICE file distributed with

--- a/skills/workflow/docs-retro/SKILL.md
+++ b/skills/workflow/docs-retro/SKILL.md
@@ -23,7 +23,6 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License. -->
----
 
 You are a docs-focused retrospective analyst for Elastic documentation sessions. Your job is to analyze Claude Code session transcripts and produce a structured report covering documentation opportunities, skill effectiveness, and missing skills.
 


### PR DESCRIPTION
## Summary

- **`sources:` frontmatter field** — All skills with upstream documentation URLs now declare them in YAML frontmatter. The freshness checker agent and workflow read from this field instead of hardcoding URLs, so adding a new skill automatically includes it in freshness checks.
- **CLAUDE.md** — Project guide for contributors using Claude Code in this repo: layout, skill anatomy, categories, conventions, gh-aw workflow docs.
- **CONTRIBUTING.md** — Detailed contribution guidelines: category taxonomy, frontmatter field guidelines (when to use `context: fork`, `argument-hint`, `sources`, etc.), eval writing guide, versioning rules, contradiction avoidance.
- **`--update` installer flag** — `./install.sh --update` compares installed skill versions against the catalog and updates any that have newer versions.
- **gh-aw update checker** — New `check-aw-updates.yml` workflow runs weekly, recompiles lock files via `gh aw compile`, and opens a PR if anything changed.
- **Eval validation in CI** — `validate-skills.yml` now also validates `evals/evals.json` files for correct JSON structure and required fields (`id`, `prompt`, `expectations`).
- **`argument-hint` on all arg-accepting skills** — Added to applies-to-tagging, content-type-checker, docs-redirects, docs-syntax-help, crosslink-validator.
- **Bugfix** — Removed stray `---` delimiter in docs-retro SKILL.md that could confuse frontmatter parsers.

## Test plan

- [ ] Verify CI passes on this PR (skill validation + eval validation)
- [ ] Run `./install.sh --list` and `./install.sh --update` locally
- [ ] Confirm skills with new `sources:` field still parse correctly as Claude Code skills
- [ ] Review CONTRIBUTING.md for completeness relative to existing skills

Generated with [Claude Code](https://claude.com/claude-code)