### PR TITLE
Make GH-AW workflows idempotent and use Elastic Docs MCP for freshness

### DIFF
--- a/.github/agents/docs-freshness-checker.agent.md
+++ b/.github/agents/docs-freshness-checker.agent.md
@@ -41,14 +41,16 @@ To find all skills and their sources:
 
 1. Find every `SKILL.md` file under the `skills/` directory.
 2. Parse the YAML frontmatter of each file.
-3. Read the `sources:` list. If a skill has no `sources:` field, skip it during freshness checks.
+3. Read the `sources:` list. If a skill has no `sources:` field, use the Elastic Docs MCP server to discover relevant upstream content (see "Skills without explicit sources" below).
 
 ## How to check freshness
 
-For each skill that has source URLs:
+For each skill:
 
 1. **Read** the SKILL.md file completely
-2. **Fetch** each source URL (append `.md` to the URL for LLM-friendly versions)
+2. **Fetch** upstream content:
+   - If `sources:` exist: fetch each source URL (append `.md` to the URL for LLM-friendly versions)
+   - If no `sources:`: use the Elastic Docs MCP server (`https://www.elastic.co/docs/_mcp/`) — call `SemanticSearch` with the skill's name and description to find relevant upstream pages, then fetch the top results with `GetDocumentByUrl` (with `includeBody: true`)
 3. **Compare** the fetched content against what the skill encodes:
    - Are all rules from the upstream source present in the skill?
    - Has any syntax changed (new options, renamed directives, changed defaults)?
@@ -101,5 +103,14 @@ If all skills are current, close the issue with a comment:
 All skills checked against upstream sources — no meaningful drift detected.
 
 - skill-name: current
-- skill-name: skipped (no sources)
+- skill-name: current (sources discovered via MCP)
 ```
+
+## Skills without explicit sources
+
+When a skill has no `sources:` frontmatter, use the Elastic Docs MCP server at `https://www.elastic.co/docs/_mcp/` to find relevant upstream documentation:
+
+1. Call `SemanticSearch` with the skill's name and a brief summary of its purpose.
+2. Review the top results — pick pages that clearly correspond to the rules or syntax the skill encodes.
+3. Fetch each candidate page with `GetDocumentByUrl` (set `includeBody: true`) and compare against the skill.
+4. If meaningful drift is found, update the skill AND add the discovered URLs to its `sources:` frontmatter so future checks can use them directly.

--- a/.github/workflows/skill-eval-test.md
+++ b/.github/workflows/skill-eval-test.md
@@ -54,7 +54,7 @@ Run eval test cases against skills changed in this PR and report results.
 1. List files changed in this PR. Identify skills that were modified (any file under `skills/<category>/<skill-name>/`).
 2. For each changed skill, check if `evals/evals.json` exists in the skill directory.
 3. If evals exist, run the evaluation process below. If no evals exist, note it and skip.
-4. Post a single comment on the PR with all results.
+4. Post results as a PR comment, updating any existing comment from a previous run (see "Comment idempotency" below).
 
 ## Running evals
 
@@ -113,6 +113,10 @@ If a skill has no evals:
 
 ⚠️ No evals found. Consider adding `evals/evals.json` with test cases.
 ```
+
+## Comment idempotency
+
+Before posting, search existing PR comments for one that starts with `## Skill Eval Results`. If found, **update that comment** instead of creating a new one. This prevents duplicate comments on re-runs.
 
 ## Important notes
 

--- a/.github/workflows/skill-freshness.md
+++ b/.github/workflows/skill-freshness.md
@@ -58,10 +58,11 @@ Check all skills in `skills/**/SKILL.md` for staleness against their upstream so
 1. Find every `SKILL.md` file under the `skills/` directory.
 2. For each skill:
    - Read the SKILL.md file.
-   - Parse the `sources:` list from its YAML frontmatter. If no `sources:` field exists, skip this skill.
-   - When fetching a source URL, always append `.md` to the URL (e.g. `https://www.elastic.co/docs/contribute-docs/style-guide` becomes `https://www.elastic.co/docs/contribute-docs/style-guide.md`). The `.md` variant returns an LLM-friendly markdown version of the page.
+   - Parse the `sources:` list from its YAML frontmatter.
+   - **If `sources:` exists**: fetch each source URL (append `.md` for the LLM-friendly variant, e.g. `https://www.elastic.co/docs/contribute-docs/style-guide.md`).
+   - **If no `sources:` field**: use the Elastic Docs MCP server (`https://www.elastic.co/docs/_mcp/`) to find relevant upstream content. Call `SemanticSearch` with the skill's name and description to discover related documentation pages. Then fetch the top results with `GetDocumentByUrl` (with `includeBody: true`) and compare them against the skill.
    - Compare the fetched content against the rules, syntax, and options encoded in the skill.
-   - If the skill is stale (new rules added, syntax changed, options removed, links broken), update the SKILL.md to reflect the current upstream state.
+   - If the skill is stale (new rules added, syntax changed, options removed, links broken), update the SKILL.md to reflect the current upstream state. If the skill lacked `sources:` and you found relevant upstream pages, add them to the frontmatter.
    - After updating a skill, run its evals to catch regressions (see "Post-update eval check" below).
 3. If any files changed, open a pull request summarizing what drifted, why, and eval results.
 4. If nothing changed, close this issue with a comment confirming all skills are current.

--- a/.github/workflows/skill-quality-review.md
+++ b/.github/workflows/skill-quality-review.md
@@ -52,7 +52,7 @@ Review skills changed in this PR for quality issues and post a comment with find
 1. List the files changed in this PR. Identify every `SKILL.md` under `skills/`.
 2. For each changed skill, read the full `SKILL.md` file.
 3. Evaluate the skill against the criteria below.
-4. Post a single comment on the PR summarizing your findings across all changed skills. This is advisory only.
+4. Post a comment on the PR summarizing your findings across all changed skills, updating any existing comment from a previous run (see "Comment idempotency" below). This is advisory only.
 
 ## Evaluation criteria
 
@@ -117,3 +117,7 @@ Looks good — clear trigger, actionable instructions, appropriate scope.
 ```
 
 Do not nitpick formatting or stylistic preferences. Focus on issues that would affect the skill's effectiveness when used by an agent.
+
+## Comment idempotency
+
+Before posting, search existing PR comments for one that starts with `## Skill Quality Review`. If found, **update that comment** instead of creating a new one. This prevents duplicate comments on re-runs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,23 @@ Agentic workflows use `.md` files compiled to `.lock.yml` via `gh aw compile`. T
 
 Use `/create-skill` within this repo, or see `CONTRIBUTING.md` for manual instructions.
 
+## Elastic Docs MCP server
+
+The Elastic documentation site exposes a public MCP server at `https://www.elastic.co/docs/_mcp/` (no auth required). Use it for searching docs, fetching pages, and checking content freshness.
+
+Available tools:
+
+| Tool | Purpose |
+|------|---------|
+| `SemanticSearch` | Search all published Elastic docs by meaning. Supports product/section filters. |
+| `FindRelatedDocs` | Discover pages related to a topic. |
+| `GetDocumentByUrl` | Fetch a specific page by URL or path. Returns title, summaries, headings, and optionally the full body. |
+| `AnalyzeDocumentStructure` | Analyze heading count, link count, parent pages for a given URL. |
+| `CheckCoherence` | Check how coherently a topic is covered across all docs. |
+| `FindInconsistencies` | Find potential inconsistencies across pages covering the same topic. |
+
+Test with: `npx @modelcontextprotocol/inspector --url https://www.elastic.co/docs/_mcp/`
+
 ## Running CI locally
 
 ```bash


### PR DESCRIPTION
## Summary

- **Comment idempotency**: `skill-eval-test` and `skill-quality-review` workflows now search for an existing comment and update it on re-runs, instead of posting duplicates.
- **MCP-based freshness**: `skill-freshness` workflow and `docs-freshness-checker` agent now use the Elastic Docs MCP server (`https://www.elastic.co/docs/_mcp/`) to discover relevant upstream content for skills that lack explicit `sources:` frontmatter. Discovered URLs are added to the skill's frontmatter when drift is found.
- **CLAUDE.md**: Documents the public Elastic Docs MCP server and its 6 tools.

## Test plan

- [ ] Verify `gh aw compile` succeeds (done locally)
- [ ] Trigger `skill-eval-test` on a PR with skill changes — confirm it updates rather than duplicates comments
- [ ] Trigger `skill-quality-review` on the same PR — same check
- [ ] Run `skill-freshness` manually — confirm it checks skills without `sources:` via MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)