### PR TITLE
Add negative evals to all skills

### DIFF
--- a/.claude/skills/create-skill/SKILL.md
+++ b/.claude/skills/create-skill/SKILL.md
@@ -100,17 +100,34 @@ After writing the file:
 3. Do NOT move on until the user confirms they're happy with the result
 4. If the user requests changes, edit the file and present the updated version again
 
-### Step 5: Generate evals
+### Step 5: Generate evals interactively
 
-After the user approves the skill, generate 2-3 test cases as `evals/evals.json` inside the skill directory. Follow the schema in `references/eval-schemas.md`.
+After the user approves the skill, generate eval test cases as `evals/evals.json` inside the skill directory. Follow the schema in `references/eval-schemas.md`.
+
+#### 5a: Draft initial evals
+
+Generate 3-4 evals covering:
+
+1. **Core use case** — the happy path the skill is designed for
+2. **Edge case** — unusual input, boundary condition, or complex scenario
+3. **Negative eval** — input where the skill should NOT trigger, flag, or produce output. This is critical to prevent false positives and over-triggering. Examples:
+   - For a linter/checker: valid input that should pass cleanly
+   - For a generator: a request that falls outside the skill's scope
+   - For an analyzer: input with nothing to report
 
 Good evals:
 - Use realistic, substantive prompts (not "do X" — include file paths, context, specifics)
 - Have expectations that are discriminating (fail when the skill doesn't work, not just pass for any output)
-- Cover the core use case, an edge case, and a validation/error scenario
+- Negative evals should use "Does NOT flag/generate/suggest" expectations
 - Test the skill's unique value-add, not things the base model already handles
 
-Present the evals to the user: "Here are the test cases I'd suggest. Do these look right, or do you want to add more?"
+#### 5b: Review with the user
+
+Present the evals and ask: **"Here are the test cases I'd suggest — including a negative eval to catch false positives. Do these cover the right scenarios, or do you want to add/change any?"**
+
+#### 5c: Iterate
+
+If the user suggests additional scenarios, failure modes, or edge cases, add them. Pay special attention to cases the user has seen in practice — real-world failures make the best evals.
 
 ### Step 6: Optimize the description (optional)
 

--- a/.claude/skills/create-skill/references/eval-schemas.md
+++ b/.claude/skills/create-skill/references/eval-schemas.md
@@ -68,5 +68,6 @@ Output from blind comparator.
 
 - **Prompts should be realistic**: Include file paths, personal context, specifics. Not abstract requests.
 - **Expectations should be discriminating**: They should fail when the skill doesn't work, not just pass for any output.
-- **2-3 evals per skill minimum**: Cover the core use case, an edge case, and a validation/error case.
+- **3-4 evals per skill minimum**: Cover the core use case, an edge case, a validation/error scenario, and a negative case.
 - **Focus on what matters**: Test the skill's unique value-add, not things the base model already handles.
+- **Always include negative evals**: At least one eval should test input where the skill should produce no findings, no output, or decline to act. Use "Does NOT flag/generate/suggest X" expectations. Without negative evals, skills drift toward over-triggering — one-sided evals create one-sided optimization.

--- a/skills/authoring/applies-to-tagging/evals/evals.json
+++ b/skills/authoring/applies-to-tagging/evals/evals.json
@@ -32,6 +32,17 @@
         "Sets serverless to unavailable",
         "Does not remove or modify the heading itself"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "Check the applies_to tags in this file:\n---\napplies_to:\n  stack: ga 9.0\n  serverless:\n    elasticsearch: ga\n    observability: ga\n---\n\n# Configure index lifecycle policies\n\nThis page explains how to set up ILM policies.",
+      "expected_output": "Reports that the applies_to frontmatter is valid with no issues",
+      "expectations": [
+        "Does NOT flag the structure as invalid — stack + serverless is a valid dimension pair",
+        "Does NOT flag the serverless subkeys as errors — elasticsearch and observability are valid project types",
+        "Does NOT suggest changes to a correctly formed applies_to block",
+        "Confirms the frontmatter is valid or produces a clean report with no issues"
+      ]
     }
   ]
 }

--- a/skills/authoring/content-type-checker/evals/evals.json
+++ b/skills/authoring/content-type-checker/evals/evals.json
@@ -22,6 +22,17 @@
         "Checks for problem-cause-solution structure",
         "Generates a report with required elements checklist"
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "Check this how-to page against the content type guidelines:\n\n# Create an API key\n\nTo create an API key for your deployment:\n\n## Before you begin\n\nYou need the `manage_api_key` cluster privilege.\n\n## Steps\n\n1. Open **Stack Management > API keys**.\n2. Click **Create API key**.\n3. Enter a name for the key.\n4. (Optional) Set an expiration date.\n5. Click **Create**.\n\n## Next steps\n\nUse the API key to authenticate REST API requests.",
+      "expected_output": "Reports that the page follows how-to guidelines well — has prerequisites, numbered steps, and next steps",
+      "expectations": [
+        "Does NOT flag the page as mismatched with the how-to content type",
+        "Recognizes the prerequisite section as correct structure",
+        "Recognizes the numbered steps as proper how-to format",
+        "Does NOT recommend converting it to a different content type"
+      ]
     }
   ]
 }

--- a/skills/authoring/docs-redirects/evals/evals.json
+++ b/skills/authoring/docs-redirects/evals/evals.json
@@ -22,6 +22,16 @@
         "Adds the entry under the redirects: key in redirects.yml",
         "Mentions searching for internal links to the old path that need updating"
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "I renamed a heading anchor from #old-setup to #setup on the same page (security/configure.md). The page itself didn't move. Should I add a redirect?",
+      "expected_output": "Explains that redirects.yml handles page-level redirects, not anchor renames on the same page, and suggests alternative approaches",
+      "expectations": [
+        "Does NOT generate a redirects.yml entry for a same-page anchor rename",
+        "Explains that redirects are for page moves, not anchor changes on the same page",
+        "Suggests searching for internal links pointing to the old anchor and updating them"
+      ]
     }
   ]
 }

--- a/skills/authoring/docs-syntax-help/evals/evals.json
+++ b/skills/authoring/docs-syntax-help/evals/evals.json
@@ -33,6 +33,17 @@
         "States that the marker count must exactly equal the list item count",
         "Provides a working example"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "Is this valid Elastic docs syntax?\n\n::::{tab-set}\n:::{tab-item} Console\n```console\nGET _cluster/health\n```\n:::\n:::{tab-item} Python\n```python\nclient.cluster.health()\n```\n:::\n::::",
+      "expected_output": "Confirms the syntax is valid — proper colon counts, correct nesting, backtick code blocks inside directives",
+      "expectations": [
+        "Does NOT flag the colon counts as wrong (4 for outer, 3 for inner is correct)",
+        "Does NOT flag the code blocks as incorrectly formatted",
+        "Confirms the syntax is valid or would build successfully",
+        "Does NOT suggest restructuring a correctly formed tab-set"
+      ]
     }
   ]
 }

--- a/skills/review/crosslink-validator/evals/evals.json
+++ b/skills/review/crosslink-validator/evals/evals.json
@@ -23,6 +23,17 @@
         "Groups results by file",
         "Reports file path and line number for any broken links"
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "Check the cross-links in this file:\n- [Install guide](../install.md)\n- [Elastic website](https://www.elastic.co)\n- [API reference](https://www.elastic.co/docs/api/overview)\n- [Local anchor](#configuration)",
+      "expected_output": "Reports that no cross-links were found — all links are relative, external HTTPS, or local anchors, none use the repo:// scheme",
+      "expectations": [
+        "Does NOT flag ../install.md as a cross-link (it's a relative link)",
+        "Does NOT flag the https:// URLs as cross-links",
+        "Does NOT flag #configuration as a cross-link (it's a local anchor)",
+        "Reports zero cross-links found or states there are no cross-links to validate"
+      ]
     }
   ]
 }

--- a/skills/review/docs-check-style/evals/evals.json
+++ b/skills/review/docs-check-style/evals/evals.json
@@ -27,6 +27,18 @@
         "Flags 'Choose' and suggests 'Select'",
         "Flags 'Click the Save button' and suggests 'Click **Save**' (no 'button' after label)"
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "Check this paragraph for style issues:\n\n\"To create a data view, open Stack Management and select **Data Views**. Enter a name and an index pattern that matches your data. Click **Save**.\"",
+      "expected_output": "Reports no or minimal style issues — the paragraph uses active voice, direct address, correct UI element formatting, and appropriate verbs",
+      "expectations": [
+        "Does NOT flag 'open' as a word choice issue (it's the correct verb for navigating to a page)",
+        "Does NOT flag 'select' as a word choice issue (it's the correct verb for choosing a menu item)",
+        "Does NOT flag 'Click **Save**' (correct UI interaction format — no 'button' after label)",
+        "Does NOT flag 'enter' as a word choice issue (it's the preferred verb for text input)",
+        "Reports the paragraph as clean or flags only minor issues"
+      ]
     }
   ]
 }

--- a/skills/workflow/docs-retro/evals/evals.json
+++ b/skills/workflow/docs-retro/evals/evals.json
@@ -25,6 +25,18 @@
         "Identifies workflows that lacked skill support",
         "Proposes names and descriptions for missing skills"
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "Run a retro on a session where the user only asked 'hello' and 'what time is it' — no docs work was done",
+      "expected_output": "Produces a retro report that correctly identifies no docs-relevant work and does not fabricate opportunities or skill gaps",
+      "expectations": [
+        "Does NOT fabricate docs opportunities from a non-docs session",
+        "Does NOT invent skill usage that didn't happen",
+        "States that no docs-related work was identified in the session",
+        "Still produces a structured report (not an error or refusal)",
+        "Does not modify any files"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a negative/false-positive eval to every skill, following the [Anthropic eval best practices](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents) recommendation to "build balanced problem sets testing both when behaviors should and shouldn't occur."

Previously, most skills only tested positive cases (detect this issue, generate this output). One-sided evals lead to one-sided optimization — skills could become overly aggressive at flagging or generating output when they shouldn't.

### New evals added

| Skill | Negative eval | Tests that... |
|-------|--------------|---------------|
| applies-to-tagging | Valid frontmatter | Correct tags aren't flagged as errors |
| content-type-checker | Well-structured how-to | Compliant pages pass cleanly |
| docs-redirects | Same-page anchor rename | Non-redirect scenarios don't produce entries |
| docs-syntax-help | Valid nested tab-set | Correct syntax isn't "fixed" |
| crosslink-validator | No cross-links present | Relative/external links aren't false-positived |
| docs-check-style | Clean paragraph | Correct style isn't flagged |
| docs-retro | Non-docs session | Empty sessions don't fabricate findings |

## Test plan

- [x] All eval JSON files pass `python3 -m json.tool` validation
- [ ] CI `validate-skills` passes
- [ ] Eval runner confirms new evals are picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)