### PR TITLE
Add Lens chart skills for Kibana docs (new `project` category)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ sources:                     # Upstream URLs this skill encodes (for freshness c
 - **authoring** — Skills that help write or edit documentation content
 - **review** — Skills that validate, lint, or check existing content
 - **workflow** — Skills for meta-tasks (retros, session analysis, project management)
+- **project** — Skills scoped to specific documentation areas (e.g., Kibana Lens charts)
 
 ## Conventions
 

--- a/skills/project/lens-chart-page/SKILL.md
+++ b/skills/project/lens-chart-page/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: lens-chart-page
+version: 1.0.0
+description: Create or update a Lens chart documentation page following Elastic docs conventions. Use when writing a new chart type page (pie, bar, metric, gauge, heat map, etc.) or updating an existing one in explore-analyze/visualize/charts/. Relies on lens-chart-settings for verifying UI labels against source code.
+allowed-tools: Read, Grep, Glob, Edit, WebFetch
+sources:
+  - https://github.com/elastic/kibana/tree/main/x-pack/platform/plugins/shared/lens/public/visualizations
+---
+<!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+or more contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright
+ownership. Elasticsearch B.V. licenses this file to you under
+the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. -->
+
+# Creating Lens Chart Documentation Pages
+
+Use these instructions when creating or updating a documentation page for a Kibana Lens chart type in `explore-analyze/visualize/charts/`.
+
+## Before writing: verify settings against source code
+
+Use the **lens-chart-settings** skill to verify all UI labels, option values, and rendering order against the Kibana source code before documenting them. Never guess UI labels.
+
+## Research resources
+
+### Kibana source code paths
+
+| Chart type | Source path |
+|------------|-------------|
+| Partition (pie, donut, treemap, mosaic, waffle) | `x-pack/platform/plugins/shared/lens/public/visualizations/partition/` |
+| XY (bar, line, area) | `x-pack/platform/plugins/shared/lens/public/visualizations/xy/` |
+| Metric | `x-pack/platform/plugins/shared/lens/public/visualizations/metric/` |
+| Datatable | `x-pack/platform/plugins/shared/lens/public/visualizations/datatable/` |
+
+Many visualizations use **shared components** (in `shared_components/`) that accept different props per chart. Always check the visualization-specific wrapper to see which props are passed, rather than assuming all shared component options are available.
+
+### EUI data visualization guidelines
+
+- [Part-to-whole comparisons](https://eui.elastic.co/docs/dataviz/types/part-to-whole-comparisons/) (pie, donut, treemap)
+- [Dashboard good practices](https://eui.elastic.co/docs/dataviz/dashboard-good-practices/)
+- [Categorical color palettes](https://eui.elastic.co/docs/dataviz/guides/color-guidelines/)
+
+### Existing content to check
+
+- **Main Lens page**: `explore-analyze/visualize/lens.md` — check for content to reference or deduplicate.
+- **Other chart pages**: `explore-analyze/visualize/charts/*.md` — follow established patterns.
+- **Shared snippets**: `explore-analyze/_snippets/lens-*.md` — reuse instead of duplicating.
+
+Key snippets:
+
+| Snippet | Purpose |
+|---------|---------|
+| `lens-prerequisites.md` | Prerequisites paragraph (data views, ES\|QL mode) |
+| `lens-rank-by-options.md` | Top values rank-by options |
+| `lens-value-advanced-settings.md` | Advanced settings for value/metric dimensions |
+| `lens-breakdown-advanced-settings.md` | Breakdown advanced settings |
+| `lens-histogram-settings.md` | Date histogram settings |
+| `line-chart-legend-settings.md` | Legend settings including Statistics (line/area) |
+| `line-chart-style-settings.md` | Style settings (line/area) |
+
+When creating a new chart page, update `lens.md` to link to it and remove any duplicated content.
+
+## File location and frontmatter
+
+Place the file at `explore-analyze/visualize/charts/<chart-type>.md` with this frontmatter:
+
+```yaml
+---
+navigation_title: <Chart type> charts
+applies_to:
+  stack: ga
+  serverless: ga
+description: Instructions and best practices for building <chart type> charts with Kibana Lens in Elastic.
+---
+```
+
+## Chart-specific dimensions
+
+| Chart type | Primary dimensions | Additional dimensions |
+|------------|-------------------|----------------------|
+| Pie / Donut | **Slice by**, **Metric** | (none) |
+| Bar / Line / Area | **Horizontal axis**, **Vertical axis** | **Breakdown** |
+| Metric | **Primary metric** | **Secondary metric**, **Maximum value** |
+| Gauge | **Metric** | **Minimum value**, **Maximum value**, **Goal** |
+| Table | **Metrics**, **Rows** | **Split metrics by** |
+
+## Page structure
+
+Follow this exact section order. Every chart page uses it consistently.
+
+### 1. Title and introduction
+
+```
+# Build <chart type> charts with {{kib}}
+```
+
+- One paragraph (2-3 sentences): what the chart does and when it's useful. Focus on purpose.
+- Weave in specific actionable constraints (e.g., "works best with a maximum of 6 slices"). Skip generic advice.
+- Do **not** create a separate "When to use" section.
+- A line: `You can create <chart type> charts in {{kib}} using [**Lens**](../lens.md).`
+- A hero image of a representative example.
+
+### 2. "Build a <chart type> chart" section
+
+Include the prerequisites snippet before the stepper:
+
+```
+:::{include} ../../_snippets/lens-prerequisites.md
+:::
+```
+
+Then use the `stepper` directive:
+
+```
+::::::{stepper}
+
+:::::{step} Access Lens
+**Lens** is {{kib}}'s main visualization editor. You can access it:
+- From a dashboard: On the **Dashboards** page, open or create the dashboard where you want to add a <chart type> chart, then add a new visualization.
+- From the **Visualize library** page by creating a new visualization.
+:::::
+
+:::::{step} Set the visualization to <Chart type>
+New visualizations often start as **Bar** charts.
+
+Using the **Visualization type** dropdown, select **<Chart type>**.
+:::::
+
+:::::{step} Define the data to show
+[Chart-specific data configuration steps]
+:::::
+
+:::::{step} Customize the chart to follow best practices
+[Best practices as a definition list]
+:::::
+
+:::::{step} Save the chart
+- If you accessed Lens from a dashboard, select **Save and return** to save the visualization and add it to that dashboard, or select **Save to library** to add the visualization to the Visualize library and reuse it later.
+- If you accessed Lens from the Visualize library, select **Save**. A menu opens and offers you to add the visualization to a dashboard and to the Visualize library.
+:::::
+
+::::::
+```
+
+Key conventions:
+- **Access Lens** and **Save the chart** steps are identical across all chart pages. Copy them verbatim.
+- **Define the data to show** lists numbered steps for chart-specific dimensions, then "Optionally:" for additional dimensions. Link dimension names to their settings sections (e.g., `[**Slice by**](#slice-by-settings)`).
+- **Customize the chart** uses **definition list** format. List 4-6 actionable best practices. End with a line pointing to the full settings reference.
+
+### 3. Advanced scenarios (optional)
+
+Only include when teaching a non-obvious technique users wouldn't discover on their own:
+- Using **formulas** (e.g., computing error rates as a percentage)
+- Configuring **multiple metrics** for completion progress (waffle)
+- Setting up **dynamic bounds or goals** from data (gauge)
+- Defining **custom color ranges** (heat map)
+- Configuring **color bands** with thresholds (gauge)
+
+Do NOT create scenarios that are just "use the chart with different fields". For simpler chart types, the Examples section is sufficient.
+
+When including scenarios:
+- Each scenario gets its own `##` or `###` heading with an anchor ID.
+- Use concrete examples based on **Kibana Sample Data** when possible.
+
+#### Sample data considerations
+
+- The `response` field in web logs is a **text** field — KQL filters must use pattern matching (`response: 2*`), not numeric comparisons.
+- In sample ecommerce data, `taxful_total_price` and `taxless_total_price` are identical.
+- Multiple comparable numeric fields are rare. When sample data doesn't support a scenario, use a conceptual example with realistic field names and add a `:::note` explaining users need to adapt to their data.
+
+### 4. "<Chart type> settings" section
+
+Document **every** configuration option in the Lens editor, organized by dimension/panel.
+
+Structure each dimension as:
+
+```
+### <Dimension> settings [<dimension>-settings]
+```
+
+Within each dimension, use **two top-level definition list entries**: `**Data**` and `**Appearance**`.
+
+**Data**:
+- List all available functions/aggregation types.
+- For each function, document the **Field** selector first, then function-specific sub-options as nested bullets.
+- **Field selector conventions**:
+  - **Top values**: Supports up to 4 fields. Multiple fields create multi-term grouping. Fields can be reordered by dragging.
+  - **Date histogram**: Single date field only.
+  - **Intervals**: Single numeric field only.
+  - **Filters**: No field selector (KQL queries reference fields directly).
+- Reuse shared snippets wherever applicable.
+
+**Appearance**:
+- List visual options: Name, Value format, Color, Series color, Color mapping, etc.
+
+After dimension-specific settings, add a `### General layout` section for global settings ({icon}\`brush\` **Style** and legend). Split into `#### Style settings` and `#### Legend settings` as needed.
+
+**Legend settings** vary by chart type:
+
+| Setting | XY charts | Partition charts | Notes |
+|---------|-----------|-----------------|-------|
+| Visibility | Yes | Yes | Auto / Show / Hide |
+| Position | Yes | No | Partition charts don't pass `location` |
+| Statistics | Yes | No | Controlled by `defaultLegendStats` |
+| Nested legend | No | Yes (>1 group) | Multiple Group by dimensions required |
+| Label truncation | Yes | Yes | |
+| Width | Yes | Yes | UI label is "Width", not "Legend size" |
+
+### 5. "<Chart type> examples" section
+
+- 2-4 real-world examples using **Kibana Sample Data**.
+- Use **definition list** format with bold example title.
+- Structure each example:
+  - `* Example based on: <sample data set name>`
+  - Configuration keys as bullet points (Slice by, Metric, Style, Legend, etc.)
+  - An image of the result, sized with `"=60%"` or `"=70%"`
+- Showcase **different features** (e.g., basic config, donut variant, filters, multiple metrics).
+
+## Chart-page-specific formatting
+
+For general syntax, refer to the **docs-syntax-help** skill. These conventions are specific to chart pages:
+
+### Images
+
+- Store at `explore-analyze/images/<image-name>.png`
+- Reference with: `![Alt text](/explore-analyze/images/<image-name>.png "=60%")`
+- Sizing: `"=50%"` for smaller inline images, `"=60%"` for examples, `"=70%"` for settings screenshots.
+- Alt text should be descriptive, not "screenshot".
+
+### Icons
+
+| Icon | Syntax | Usage |
+|------|--------|-------|
+| Style/brush | `{icon}\`brush\`` | Style settings panel |
+| Layer settings | `{icon}\`app_management\`` | Layer settings (9.3+/Serverless) |
+| Actions menu | `{icon}\`boxes_horizontal\`` | Layer actions menu (9.0-9.2) |
+| Add layer | `{icon}\`plus_in_square\`` | Add layer button |
+
+For the legend icon, use: `![Legend icon](/explore-analyze/images/kibana-legend-icon.svg "")`
+
+### Version-specific UI patterns
+
+When UI differs between versions:
+
+```
+* {applies_to}`serverless: ga` {applies_to}`stack: ga 9.3` Select {icon}`app_management` **Layer settings**.
+* {applies_to}`stack: ga 9.0-9.2` Select {icon}`boxes_horizontal`, then select **Layer settings**.
+```
+
+### Cross-references
+
+- Other chart types: `[bar charts](bar-charts.md)`
+- Lens page: `[**Lens**](../lens.md)`
+- Lens features: `[Assign colors to terms](../lens.md#assign-colors-to-terms)`
+- Sample data: `[sample data](/manage-data/ingest/sample-data.md)`
+
+### Internal links
+
+Link from steps to settings sections:
+
+```
+2. Configure the [**Slice by**](#slice-by-settings) dimension.
+3. Configure the [**Metric**](#metric-settings) dimension.
+```
+
+Link from best practices to advanced scenarios when relevant.
+
+### Variables
+
+Use `{{kib}}` (Kibana), `{{es}}` (Elasticsearch), `{{data-source}}` (data view / data source).
+
+## Checklist
+
+- [ ] Frontmatter has `navigation_title`, `applies_to`, and `description`
+- [ ] Hero image exists and is referenced
+- [ ] "Build a chart" stepper uses standard Access Lens / Save steps
+- [ ] Prerequisites snippet included before the stepper
+- [ ] All settings verified against Kibana source code (use lens-chart-settings skill)
+- [ ] All settings from the Lens editor are documented in the Settings section
+- [ ] Shared snippets included where applicable (not duplicated)
+- [ ] Examples use Kibana Sample Data and include images
+- [ ] Internal links from steps to settings sections
+- [ ] Links from best practices to related advanced scenarios
+- [ ] `lens.md` updated to link to the new page

--- a/skills/project/lens-chart-page/evals/evals.json
+++ b/skills/project/lens-chart-page/evals/evals.json
@@ -1,0 +1,49 @@
+{
+  "skill_name": "lens-chart-page",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I'm creating a new documentation page for heat map charts. What sections should the page have and in what order?",
+      "expected_output": "Lists the five required sections in order: title/intro, Build a chart stepper, optional advanced scenarios, Settings reference, and Examples",
+      "expectations": [
+        "Lists title and introduction as the first section",
+        "Lists the Build a chart stepper as the second section",
+        "Lists the Settings reference section",
+        "Lists the Examples section as the last section",
+        "Mentions that advanced scenarios are optional and only for non-obvious techniques"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Should I include an advanced scenario section for a treemap chart page that shows how to use treemaps with different fields?",
+      "expected_output": "Advises against it — scenarios that amount to 'pick different fields' belong in Examples, not in advanced scenarios. Treemap is a simpler chart type where Examples are usually sufficient.",
+      "expectations": [
+        "Advises against creating the advanced scenario section for this case",
+        "Explains that 'use the chart with different fields' is not genuinely advanced",
+        "Suggests putting it in the Examples section instead",
+        "Mentions that simpler chart types like treemap usually only need Examples"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "How should I document the settings for a pie chart's Slice by dimension?",
+      "expected_output": "Explains the two-part structure: Data (listing aggregation functions with field selectors and sub-options) and Appearance (visual options). Mentions using shared snippets for rank-by and breakdown advanced settings.",
+      "expectations": [
+        "Describes the two top-level definition list entries: Data and Appearance",
+        "Mentions listing aggregation functions under Data",
+        "Mentions documenting Field selector conventions (Top values supports multiple fields)",
+        "Mentions reusing shared snippets like lens-rank-by-options.md or lens-breakdown-advanced-settings.md"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "I need to verify the UI labels before writing the settings section. How should I do that?",
+      "expected_output": "Directs to the lens-chart-settings skill for verifying labels against the Kibana source code. Emphasizes never guessing UI labels.",
+      "expectations": [
+        "References the lens-chart-settings skill as the tool for verification",
+        "States that UI labels must be verified against source code, not guessed",
+        "Delegates the specifics of how to verify (source code paths, i18n keys) to lens-chart-settings rather than duplicating them"
+      ]
+    }
+  ]
+}

--- a/skills/project/lens-chart-settings/SKILL.md
+++ b/skills/project/lens-chart-settings/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: lens-chart-settings
+version: 1.0.0
+description: Verify Kibana Lens chart UI settings against the source code. Use when documenting chart types, reviewing chart settings accuracy, or checking UI labels and rendering order for Lens visualizations (bar, line, area, pie, treemap, mosaic, waffle, tag cloud, heat map, gauge, metric, region map, table).
+context: fork
+allowed-tools: Read, Grep, Glob, WebFetch
+sources:
+  - https://github.com/elastic/kibana/tree/main/x-pack/platform/plugins/shared/lens/public/visualizations
+---
+<!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+or more contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright
+ownership. Elasticsearch B.V. licenses this file to you under
+the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. -->
+
+# Verifying Kibana Lens Chart Settings from Source Code
+
+When documenting Lens chart settings, always verify labels, options, and rendering order against the Kibana source code. Do NOT guess UI labels.
+
+## Key Principles
+
+1. **UI labels come from i18n `defaultMessage` strings** — always extract the exact label.
+2. **Rendering order in JSX = rendering order in the UI** — document settings in the same order they appear in the component tree.
+3. **Conditional rendering is everywhere** — many settings only appear under specific conditions (chart type, selected options, number of dimensions). Trace the conditions.
+4. **Shared components are parameterized per chart** — the same `LegendSettings` component behaves differently for treemaps vs waffle vs pie based on props.
+
+## Source Code Layout
+
+### Partition charts (pie, donut, treemap, mosaic, waffle)
+
+All partition-type charts share code under:
+
+```
+x-pack/platform/plugins/shared/lens/public/visualizations/partition/
+├── partition_charts_meta.ts          # Per-chart config (toolbar options, legend config)
+├── toolbar/
+│   ├── style_settings.tsx            # Orchestrates Style panel sections
+│   ├── titles_and_text_setttings.tsx # Slice labels + Slice values options
+│   ├── appearance_settings.tsx       # Donut hole (pie/donut only)
+│   └── legend_settings.tsx           # Partition-specific legend wrapper
+```
+
+Shared legend component:
+
+```
+x-pack/platform/plugins/shared/lens/public/shared_components/legend/
+├── legend_settings.tsx               # Main legend settings (Visibility, Size, Truncation, Nested, Stats)
+├── location/legend_location_settings.tsx  # Position (only when `location` prop is defined)
+└── size/legend_size_settings.tsx     # Width/Size dropdown
+```
+
+### Other chart types
+
+Each chart type has its own directory under `visualizations/`:
+- `visualizations/xy/` for bar, line, area
+- `visualizations/heatmap/`
+- `visualizations/gauge/`
+- `visualizations/metric/`
+- `visualizations/tagcloud/`
+
+## Verification Workflow
+
+### Step 1: Find the chart metadata
+
+For partition charts, start with `partition_charts_meta.ts`. This file defines per-chart:
+- `toolbar.categoryOptions` — Slice labels options (or empty array if none)
+- `toolbar.numberOptions` — Slice values options (or empty array if none)
+- `toolbar.emptySizeRatioOptions` — Donut hole options (pie/donut only)
+- `toolbar.isDisabled` — Whether the Style panel is disabled entirely (waffle)
+- `legend.defaultLegendStats` — Enables Statistics/Show value in legend (waffle only)
+- `legend.hideNestedLegendSwitch` — Hides the Nested toggle (waffle)
+- `legend.getShowLegendDefault` — Default legend visibility behavior for Auto mode
+- `maxBuckets` — Maximum Group by dimensions
+
+### Step 2: Trace the Style settings
+
+Read `toolbar/style_settings.tsx` to understand the Style panel structure:
+
+- If `emptySizeRatioOptions` exists → renders **Appearance** accordion + **Titles and text** accordion
+- If not → renders only `PartitionTitlesAndTextSettings` directly (no sub-headers)
+
+Then read `toolbar/titles_and_text_setttings.tsx`:
+- `categoryOptions` renders as the first button group (label: check i18n key `xpack.lens.pieChart.labelSliceLabels`)
+- `numberOptions` renders as the second button group (label: check i18n key `xpack.lens.pieChart.sliceValues`)
+- If `numberDisplay === 'percent'`, a **Decimal places** input appears
+
+If `categoryOptions` is empty, the first button group is hidden. If `numberOptions` is empty, the second button group is hidden. If `isDisabled` is true, the entire section is disabled/hidden.
+
+### Step 3: Trace the Legend settings
+
+Read `toolbar/legend_settings.tsx` (partition wrapper) to see what props are passed to the shared `LegendSettings` component. Key props to check:
+
+| Prop | What it controls | How to verify |
+|------|-----------------|---------------|
+| `legendOptions` | Visibility options (Auto/Show/Hide) | Always present for all partition charts |
+| `position` | Only renders if `location` is also passed | Partition charts do NOT pass `location` → Position hidden |
+| `renderNestedLegendSwitch` | Nested toggle | `!hideNestedLegendSwitch && groups > 1` |
+| `allowedLegendStats` | Statistics/Show value | Only if `defaultLegendStats` defined in chart meta |
+| `legendSize` / `onLegendSizeChange` | Width dropdown | Renders if `isVerticalLegend` is true |
+| `shouldTruncate` / `onTruncateLegendChange` | Label truncation toggle | Always present when legend not hidden |
+| `showAutoLegendSizeOption` | Auto in size dropdown | Only for pre-8.3 visualizations |
+
+### Step 4: Determine rendering order
+
+Read the shared `legend_settings.tsx` JSX top to bottom. For partition charts (no `location` prop), the actual rendering order is:
+
+1. **Visibility** (always)
+2. **Width** (when legend not hidden, via LegendSizeSettings)
+3. **Label truncation** + **Line limit** (when legend not hidden)
+4. **Nested** (when legend not hidden AND multiple groups AND not hideNestedLegendSwitch)
+
+Settings that do NOT render for partition charts:
+- **Position** — requires `location` prop (only XY charts pass this)
+- **Statistics** — requires `allowedLegendStats.length > 1`
+- **Show value** — requires exactly 1 allowed legend stat of type Value/CurrentAndLastValue
+
+### Step 5: Verify option labels
+
+For each button group or dropdown, check the `label` or `inputDisplay` in the options array. Common pitfalls:
+
+| What you might assume | Actual UI label | Source |
+|-----------------------|----------------|--------|
+| "Labels" | "Slice labels" | `xpack.lens.pieChart.labelSliceLabels` |
+| "Values" | "Slice values" | `xpack.lens.pieChart.sliceValues` |
+| "Legend size" | "Width" | `xpack.lens.shared.legendSizeSetting.label` |
+| "Truncate" | "Label truncation" | `xpack.lens.shared.labelTruncation` |
+| "Max lines" | "Line limit" | `xpack.lens.shared.maxLinesLabel` |
+| "Show" (legend) | "Show" | `xpack.lens.pieChart.legendVisibility.show` |
+
+## Quick Reference: Per-Chart Differences
+
+| Feature | Pie/Donut | Treemap | Mosaic | Waffle |
+|---------|-----------|---------|--------|--------|
+| Slice labels | Hide/Inside/Auto | Hide/Show | (none) | (none) |
+| Slice values | Hide/Integer/Percentage | Hide/Integer/Percentage | Hide/Integer/Percentage | (none) |
+| Donut hole | Yes | No | No | No |
+| Style panel disabled | No | No | No | Yes |
+| Legend Position | No | No | No | No |
+| Legend Width | Yes | Yes | Yes | Yes |
+| Nested legend | Yes (>1 group) | Yes (>1 group) | Yes (>1 group) | No |
+| Show value | No | No | No | Yes |
+| Statistics | No | No | No | No |
+| Default legend visibility | Auto shows when >1 bucket | Auto hides | Auto hides | Auto shows always |
+| Max Group by dimensions | 3 | 2 | 2 | 1 |
+| Color mapping | First Group by only | First Group by only | Vertical axis | Group by |
+
+## Common Mistakes to Avoid
+
+1. **Assuming Position exists for partition charts** — it doesn't. Only XY-type charts have Position.
+2. **Using "Legend size" instead of "Width"** — the actual label is "Width".
+3. **Including Auto in Width options** — Auto only shows for pre-8.3 visualizations.
+4. **Documenting Statistics for non-waffle charts** — only waffle has `defaultLegendStats`.
+5. **Assuming "Titles and text" sub-header exists for all charts** — it only appears when `emptySizeRatioOptions` is defined (pie/donut).
+6. **Getting the Nested legend condition wrong** — it requires both `hideNestedLegendSwitch !== true` AND multiple Group by dimensions.
+7. **Assuming color mapping works on all Group by levels** — only available on the first dimension.

--- a/skills/project/lens-chart-settings/evals/evals.json
+++ b/skills/project/lens-chart-settings/evals/evals.json
@@ -1,0 +1,47 @@
+{
+  "skill_name": "lens-chart-settings",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I need to document the legend settings for a treemap chart. Does treemap have a Position option in its legend?",
+      "expected_output": "Explains that treemap (a partition chart) does not have a Position option because partition charts don't pass the `location` prop to the shared LegendSettings component. Only XY charts have Position.",
+      "expectations": [
+        "States that treemap does NOT have a legend Position option",
+        "Explains that Position requires the `location` prop, which partition charts don't pass",
+        "Mentions that only XY-type charts (bar, line, area) have Position"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Where in the Kibana source code should I look to find what Style panel options are available for a pie chart?",
+      "expected_output": "Directs to partition_charts_meta.ts for the chart config, then toolbar/style_settings.tsx for the panel structure, and toolbar/titles_and_text_setttings.tsx for slice labels and values",
+      "expectations": [
+        "Points to partition_charts_meta.ts as the starting point for per-chart configuration",
+        "Mentions toolbar/style_settings.tsx for the Style panel structure",
+        "Mentions toolbar/titles_and_text_setttings.tsx for slice labels and values options",
+        "References the path x-pack/platform/plugins/shared/lens/public/visualizations/partition/"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I wrote 'Legend size' as the label for the legend width dropdown in my chart docs. Is that correct?",
+      "expected_output": "Corrects the label to 'Width', citing the i18n key xpack.lens.shared.legendSizeSetting.label",
+      "expectations": [
+        "States the correct UI label is 'Width', not 'Legend size'",
+        "References the i18n key or source code as evidence",
+        "Lists this as a common mistake to avoid"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "What's the difference between waffle charts and other partition charts when it comes to legend settings?",
+      "expected_output": "Explains that waffle has Show value (via defaultLegendStats), no Nested toggle (hideNestedLegendSwitch is true), and always shows legend by default in Auto mode",
+      "expectations": [
+        "Mentions waffle has Show value in legend (via defaultLegendStats)",
+        "Mentions waffle hides the Nested legend switch",
+        "Mentions waffle's Auto legend visibility shows always (vs other partition charts)",
+        "Notes that waffle has max 1 Group by dimension vs 2-3 for other partition types"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds two new skills under a new `project` category for documentation area-specific skills:
  - **`lens-chart-settings`**: Navigate the Kibana Lens source code to verify chart UI labels, rendering order, and conditional settings against the actual implementation. Read-only skill (`context: fork`).
  - **`lens-chart-page`**: Author Lens chart documentation pages following established conventions (page structure, stepper, settings reference, examples). References `lens-chart-settings` for source code verification.
- Updates `CLAUDE.md` to document the new `project` category.
- Both skills include evals.

### Design decisions

- **Two skills instead of one**: The code navigation skill (`lens-chart-settings`) is a verification/research tool that can be used independently, while the authoring skill (`lens-chart-page`) depends on it for accuracy. Keeping them separate allows the settings skill to be used for reviews too.
- **Content trimmed for efficiency**: The authoring skill was condensed from ~460 lines to ~290 lines by removing content already covered by `docs-syntax-help` (directive syntax), `docs-check-style` (writing style, linting), and `applies-to-tagging` (applies-to syntax). Only chart-page-specific conventions are retained.
- **New `project` category**: These skills are scoped to a specific documentation area (Kibana Lens charts) rather than being general-purpose authoring or review skills. The `project` category keeps them organized separately.

### Origin

These skills were created using the **create-skill** skill, based on existing instructions from the `docs-content` repository (`.cursor/skills/kibana-lens-chart-settings/SKILL.md` and `.cursor/lens-chart-page-instructions.md`).

## Test plan

- [ ] CI validation passes (`validate-skills.yml` — frontmatter, name/directory match, SemVer, eval JSON structure)
- [ ] `lens-chart-settings` skill accurately reflects Kibana Lens source code structure and verification workflow
- [ ] `lens-chart-page` skill produces chart pages that match existing patterns in `explore-analyze/visualize/charts/`
- [ ] No contradictions between these skills and `docs-syntax-help`, `docs-check-style`, or `applies-to-tagging`


Made with [Cursor](https://cursor.com)