### PR TITLE
Add page-opening-optimizer skill (authoring)

### DIFF
--- a/skills/authoring/page-opening-optimizer/SKILL.md
+++ b/skills/authoring/page-opening-optimizer/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: page-opening-optimizer
+version: 1.0.0
+description: Optimize the opening of an Elastic documentation page — H1 title, opening paragraph, and requirements section — following doc type conventions. Use when writing or improving page intros, optimizing titles for discoverability, adding requirements sections, or when the user asks to improve the first lines of a doc page.
+argument-hint: <file-or-directory>
+allowed-tools: Read, Grep, Glob, Edit, Shell
+sources:
+  - https://www.elastic.co/docs/contribute-docs/content-types/overviews
+  - https://www.elastic.co/docs/contribute-docs/content-types/how-tos
+  - https://www.elastic.co/docs/contribute-docs/content-types/tutorials
+---
+<!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+or more contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright
+ownership. Elasticsearch B.V. licenses this file to you under
+the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. -->
+
+You are a page opening optimizer for Elastic documentation. Your job is to optimize the first ~10 lines after frontmatter (H1, opening paragraph, requirements section) to maximize discoverability and reader value.
+
+## Inputs
+
+`$ARGUMENTS` is a file path or directory. If a directory, process all `.md` files. If empty, ask the user what to optimize.
+
+## Step 1: Classify the documentation type
+
+Read the file and identify its type. This determines H1 style, opening tone, and whether to add requirements.
+
+| Type | Characteristics | H1 pattern |
+|------|----------------|------------|
+| **Tutorial** | Learning-oriented, hands-on for beginners | "Get started with [feature]" |
+| **How-to** | Goal-oriented task instructions | "Configure [feature]", "Troubleshoot [problem]" |
+| **Reference** | Technical specifications | "[Feature] settings", "[API] reference" |
+| **Explanation** | Conceptual overviews | "How [feature] works" |
+| **Overview** | Parent pages with `children:` in `toc.yml` | Feature name only |
+
+To detect overview pages, check `toc.yml` for entries with `children:` pointing to the file.
+
+## Step 2: Optimize the H1 title
+
+The H1 must be:
+
+1. **Discoverable** — include the feature name and context (e.g., "in Kibana", "with ES|QL")
+2. **Specific** — clearly indicate what the page covers
+3. **Unique** — no other page should share this title
+4. **Anchored** — always include `[anchor-name]` in brackets
+
+```markdown
+# Configure data views in Kibana [configure-data-views]
+```
+
+If the H1 exceeds ~50 characters, add `navigation_title` to the frontmatter.
+
+## Step 3: Write the opening paragraph
+
+The opening paragraph (2-4 sentences) immediately follows the H1. It must NOT repeat the frontmatter `description`.
+
+### By doc type
+
+**Tutorial** — Define the feature, explain how it works, state what the tutorial covers:
+```markdown
+Elasticsearch Query Language ({{esql}}) makes it easier to explore your data
+in **Discover**. {{esql}} uses a piped syntax to filter, transform, and aggregate
+data. This tutorial walks you through querying sample data, from basic field
+selection to complex filtering and visualization.
+```
+
+**How-to** — Define the feature, explain what it does, state the value:
+```markdown
+Pattern analysis in **Discover** helps you find patterns in unstructured log
+messages by performing categorization analysis on text fields. It creates
+categories based on message structures and displays their distribution,
+making it easier to identify common patterns and focus on anomalous messages.
+```
+
+**Reference** — Define the subject, state its purpose:
+```markdown
+API keys provide secure, token-based authentication for applications accessing
+{{product.elasticsearch}}. Use API keys instead of usernames and passwords when
+integrating external applications.
+```
+
+**Explanation** — Establish context, state what concepts are covered:
+```markdown
+{{product.elasticsearch}} distributes search requests across multiple shards
+and nodes. Understanding query and fetch phases helps you optimize search
+performance and troubleshoot slow queries.
+```
+
+**Overview** — State what the feature is, its value, and key capabilities:
+```markdown
+**Discover** is the primary tool for exploring your data in {{product.kibana}}.
+Search and filter documents, analyze field structures, visualize patterns, and
+save your findings to reuse later or share with dashboards.
+```
+
+### Key principles
+
+- Don't repeat the frontmatter `description`
+- Don't have two consecutive paragraphs repeating each other
+- Front-load important information
+- Use complete sentences, not bullet-point fragments
+- Spell out acronyms on first use: "Elasticsearch Query Language ({{esql}})"
+
+## Step 4: Add a requirements section
+
+Add `## Requirements` **only when** all conditions are met:
+- No existing requirements/prerequisites section in the first 50 lines
+- The page is **not** an overview page
+- At least one requirement is non-obvious
+
+### What to include
+
+- Specific Kibana privilege levels: **All**, **Read**, or **None** for a named feature
+- Non-obvious prerequisites (data that must exist, external systems, special licenses)
+- Version requirements only if the feature requires version > 9.0
+
+### What to exclude
+
+- Obvious prerequisites ("an existing dashboard" on "Edit a dashboard")
+- Generic system requirements ("access to Kibana", "Elasticsearch must be running")
+- Procedural details that belong in the main body
+- Version numbers prior to 9.0
+
+### Format
+
+Use an H2 with a descriptive anchor:
+```markdown
+## Requirements [create-dashboard-requirements]
+
+To create dashboards, you need:
+
+* [Data indexed into {{product.elasticsearch}}](/manage-data/ingest.md) and a [data view](../data-views.md).
+* **All** privilege for the **Dashboard** feature in {{product.kibana}}.
+```
+
+For pages with few H2 sections and a single simple requirement, use a paragraph instead:
+```markdown
+You need the **All** privilege for the **Dashboard** feature.
+```
+
+## Step 5: Enforce substitutions
+
+Replace hardcoded product names with Jinja2 substitutes:
+- `{{product.kibana}}`, `{{product.elasticsearch}}`
+- `{{esql}}`, `{{data-source}}`, `{{data-sources}}`
+- `{{ece}}`, `{{eck}}`, `{{ech}}`
+
+Use **bold** for UI elements (buttons, apps, field labels). Use `monospace` for technical elements (commands, file paths, settings).
+
+## Step 6: Lint
+
+Run Vale on the modified file immediately after editing. Fix all errors in the opening section before moving to the next file.
+
+```bash
+vale <file>
+```
+
+## Pre-flight checks
+
+Before modifying any file, verify:
+
+1. **Important/warning admonitions** in the first ~20 lines — **never** modify, move, or rewrite them. Edit only the content around them.
+2. **Overview page** (has `children:` in `toc.yml`) — do **not** add a requirements section.
+3. **Pre-9.0 version references** — remove them (these docs are for Stack 9+). Only keep versions > 9.0.
+
+## Quality checklist
+
+- [ ] Doc type correctly identified
+- [ ] H1 is unique, specific, searchable, and has an anchor
+- [ ] `navigation_title` added if H1 > 50 characters
+- [ ] Opening paragraph doesn't repeat frontmatter description
+- [ ] Opening conveys purpose, value, and scope
+- [ ] Requirements section added where appropriate (not on overview pages)
+- [ ] All substitutions used (no hardcoded product names)
+- [ ] Acronyms spelled out on first use
+- [ ] Bold for UI elements, monospace for technical elements
+- [ ] No pre-9.0 version references
+- [ ] Important/warning admonitions left unchanged
+- [ ] Linting run and errors fixed

--- a/skills/authoring/page-opening-optimizer/evals/evals.json
+++ b/skills/authoring/page-opening-optimizer/evals/evals.json
@@ -1,0 +1,62 @@
+{
+  "skill_name": "page-opening-optimizer",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Optimize the opening of this how-to page:\n\n---\napplies_to:\n  stack: ga\n  serverless: ga\ndescription: Learn how to use pattern analysis to find log patterns.\n---\n\n# Pattern analysis\n\nYou can use pattern analysis in Discover to find patterns in your log data. It helps you find common patterns.",
+      "expected_output": "Improved H1 with anchor, a richer opening paragraph that defines what pattern analysis is and its value, and a suggestion to add a requirements section",
+      "expectations": [
+        "Adds an anchor to the H1 (e.g., [pattern-analysis] or similar)",
+        "Rewrites the opening paragraph to define what pattern analysis is and explain its value",
+        "Does not repeat the frontmatter description verbatim in the opening paragraph",
+        "Replaces 'Discover' with bold formatting (**Discover**) as a UI element",
+        "Considers whether a requirements section is appropriate"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Optimize this overview page opening. The toc.yml shows it has children.\n\n---\napplies_to:\n  stack: ga\n  serverless: ga\n---\n\n# Dashboards\n\nDashboards let you visualize your data.\n\n## Requirements\n\n- Access to Kibana",
+      "expected_output": "Expanded opening paragraph with value proposition and key capabilities, removal of the requirements section since this is an overview page",
+      "expectations": [
+        "Identifies the page as an overview type (has children in toc.yml)",
+        "Does NOT keep or add a requirements section for an overview page",
+        "Expands the opening paragraph to include value proposition and key capabilities",
+        "Uses {{product.kibana}} substitution instead of hardcoded 'Kibana'"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Optimize the opening for this tutorial page:\n\n---\napplies_to:\n  stack: ga\n  serverless: ga\n---\n\n# ES|QL tutorial\n\nES|QL is a query language. This tutorial shows you how to use it.\n\n## Prerequisites\n\n- Kibana version 8.0 or later\n- Some data to query",
+      "expected_output": "Improved H1 with context and anchor, acronym spelled out on first use, version reference updated, substitutions applied",
+      "expectations": [
+        "Improves the H1 to be more discoverable (e.g., 'Query your data with ES|QL in Discover')",
+        "Adds an anchor to the H1",
+        "Spells out the acronym on first use: 'Elasticsearch Query Language ({{esql}})'",
+        "Removes the pre-9.0 version reference ('version 8.0 or later')",
+        "Replaces hardcoded 'Kibana' with {{product.kibana}} substitution"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Optimize this page opening. There is a warning admonition right after the H1:\n\n---\napplies_to:\n  stack: ga\n  serverless: ga\n---\n\n# Background search [background-search]\n\nRun searches in the background.\n\n::::{important} - Background search replaces Search sessions\nBackground search is a feature introduced in version 9.2. It replaces the deprecated **Search sessions** feature.\n::::\n\nTo run a background search, click the button.",
+      "expected_output": "Opening paragraph improved but the important admonition left completely unchanged",
+      "expectations": [
+        "Does NOT modify the important admonition text, formatting, or position",
+        "Improves the opening paragraph between the H1 and the admonition",
+        "Preserves the admonition title format ('- Background search replaces Search sessions')",
+        "Does NOT move the admonition to a different position"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Check if this reference page opening needs optimization:\n\n---\napplies_to:\n  stack: ga\n  serverless: ga\ndescription: Complete list of Kibana advanced settings.\n---\n\n# Kibana advanced settings reference [kibana-advanced-settings]\n\nKibana advanced settings control the behavior of Kibana. Use **Stack Management > Advanced Settings** to modify these values. Changes take effect immediately for all users.\n\n## General settings",
+      "expected_output": "Report that the opening is already well-structured with minimal changes needed, possibly just substitution fixes",
+      "expectations": [
+        "Recognizes this as a reference page type",
+        "Does NOT recommend adding a requirements section to a reference page",
+        "Suggests replacing hardcoded 'Kibana' with {{product.kibana}} substitution",
+        "Does not recommend major restructuring since the opening is already functional"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a new `authoring/page-opening-optimizer` skill that optimizes the first ~10 lines of Elastic documentation pages (H1 title, opening paragraph, and requirements section)
- Covers all five doc types (tutorial, how-to, reference, explanation, overview) with type-specific patterns
- Includes pre-flight checks (preserve admonitions, skip requirements on overview pages, remove pre-9.0 versions) and a quality checklist
- Includes 5 evals covering how-to, overview, tutorial, admonition-preservation, and reference page scenarios

## Test plan

- [ ] Verify SKILL.md has valid frontmatter (name matches directory, valid SemVer)
- [ ] Verify evals.json has valid structure
- [ ] Run the skill against a sample how-to page and verify H1/opening/requirements optimization
- [ ] Run the skill against an overview page and verify it does NOT add a requirements section
- [ ] Run the skill against a page with an important admonition and verify the admonition is preserved unchanged


Made with [Cursor](https://cursor.com)