### PR TITLE
Add frontmatter-description skill (authoring)

### DIFF
--- a/skills/authoring/frontmatter-description/SKILL.md
+++ b/skills/authoring/frontmatter-description/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: frontmatter-description
+version: 1.0.0
+description: Generate or improve meta descriptions in Elastic documentation frontmatter following SEO best practices. Use when adding description fields to doc pages, auditing missing descriptions, or improving metadata for search discoverability.
+argument-hint: <file-or-directory>
+allowed-tools: Read, Grep, Glob, Edit
+sources:
+  - https://developers.google.com/search/docs/appearance/snippet
+---
+<!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+or more contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright
+ownership. Elasticsearch B.V. licenses this file to you under
+the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. -->
+
+You are a meta description writer for Elastic documentation. Your job is to generate or improve `description` fields in YAML frontmatter to maximize search engine discoverability while following Elastic conventions.
+
+## Inputs
+
+`$ARGUMENTS` is a file path or directory. If a directory, process all `.md` files. If empty, ask the user what to work on.
+
+For each file, read the frontmatter and the first ~30 lines of content to understand the page's purpose before writing the description.
+
+## Constraints
+
+All descriptions must meet these requirements:
+
+| Rule | Detail |
+|------|--------|
+| **Length** | Maximum 200 characters |
+| **Tone** | Action-oriented, value-focused, factual and impersonal |
+| **Voice** | No "you can", "users can", or "this page explains" |
+| **Sentences** | Complete sentences, not fragments or labels |
+| **Context** | Include "with [feature/tool]" to establish scope |
+| **Substitutions** | Plain text only — no Jinja2 variables (`{{kib}}`, `{{es}}`) since they aren't parsed in frontmatter |
+| **Forbidden words** | "teaching", "enable", "disable", or condescending/excluding terms |
+| **No versions** | Don't mention version numbers |
+| **No colons** | Don't include `:` after `description:` — it breaks YAML parsing |
+| **Uniqueness** | Each description must be unique to its page |
+
+## Content type patterns
+
+Identify the doc type first — it determines how to start the description.
+
+### Tutorials
+
+Start with "Step-by-step tutorial for...":
+```yaml
+description: Step-by-step tutorial for building a time series dashboard with ecommerce data, including custom intervals, percentiles, and multi-layer visualizations.
+```
+
+### Troubleshooting pages
+
+Start with "Troubleshooting guide for...":
+```yaml
+description: Troubleshooting guide for Graph API issues including missing results, slow performance, and noisy connections. Understand sampling strategies and limitations.
+```
+
+### Reference pages
+
+Work "reference" naturally into the sentence (not as a label prefix):
+```yaml
+description: Compare visualization capabilities across Lens, TSVB, aggregation-based editors, Vega, and Timelion. Reference tables list supported chart types, features, and aggregations.
+```
+
+### Standard how-to / procedural pages
+
+No label prefix — lead with the action:
+```yaml
+description: Add interactive filter controls to dashboards with Options lists, Range sliders, and Time sliders. Filter data dynamically and focus on specific segments.
+```
+
+### Overview / explanation pages
+
+Lead with what the feature does and its value:
+```yaml
+description: Detect patterns in unstructured logs with Discover's pattern analysis. Categorize log messages, identify common structures, and filter out noise during troubleshooting.
+```
+
+## Anti-patterns
+
+**Never use label prefixes with dashes:**
+```yaml
+# WRONG
+description: Reference - Compare visualization capabilities...
+description: Tutorial - Build time series dashboards...
+description: Guide - Manage dashboards by searching...
+```
+
+**Never use fragments or incomplete sentences:**
+```yaml
+# WRONG
+description: Dashboard creation and management.
+description: How to configure alerts.
+```
+
+## Workflow
+
+For each file:
+
+1. **Read** the frontmatter and first ~30 lines of body content
+2. **Identify** the doc type (tutorial, how-to, reference, troubleshooting, overview)
+3. **Check** if a `description` field already exists
+4. **Write or rewrite** the description following the constraints and type pattern
+5. **Verify** length is ≤ 200 characters
+6. **Edit** the frontmatter to add or update the `description` field
+
+When processing a directory, also skip files where the entire folder already has complete descriptions — only edit files that are missing or have subpar descriptions.
+
+## Report
+
+After processing, summarize:
+- Files updated (with old → new description if rewritten)
+- Files skipped (already had good descriptions)
+- Files missing descriptions (if any remain)

--- a/skills/authoring/frontmatter-description/evals/evals.json
+++ b/skills/authoring/frontmatter-description/evals/evals.json
@@ -1,0 +1,63 @@
+{
+  "skill_name": "frontmatter-description",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Add a description to this how-to page frontmatter:\n\n---\napplies_to:\n  stack: ga\n  serverless: ga\n---\n\n# Add controls to dashboards [add-controls]\n\nAdd interactive filter controls to dashboards to let viewers dynamically filter the displayed data. Controls support Options lists for field value selection, Range sliders for numeric ranges, and Time sliders for time-based filtering.",
+      "expected_output": "A description field added to the frontmatter, under 200 characters, action-oriented, no label prefix",
+      "expectations": [
+        "Generates a description that is 200 characters or fewer",
+        "Does NOT start with a label prefix like 'Guide -' or 'How-to -'",
+        "Uses plain text (no Jinja2 substitutions like {{product.kibana}})",
+        "Writes a complete sentence, not a fragment",
+        "Mentions controls or filtering as the key topic"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Write a description for this tutorial page:\n\n---\napplies_to:\n  stack: ga\n  serverless: ga\n---\n\n# Get started with Elasticsearch [elasticsearch-get-started]\n\nThis tutorial walks you through setting up Elasticsearch, indexing your first documents, and running basic search queries.",
+      "expected_output": "A description starting with 'Step-by-step tutorial for...'",
+      "expectations": [
+        "Description starts with 'Step-by-step tutorial for' or similar tutorial-indicating phrase",
+        "Is 200 characters or fewer",
+        "Does NOT use 'Tutorial -' as a label prefix",
+        "Uses plain text ('Elasticsearch' not '{{product.elasticsearch}}')"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "This page has a bad description. Improve it:\n\n---\napplies_to:\n  stack: ga\n  serverless: ga\ndescription: Reference - Kibana settings for advanced users.\n---\n\n# Kibana advanced settings reference [advanced-settings]\n\nKibana advanced settings control the behavior of Kibana. Adjust appearance, search defaults, notifications, and other system-wide options from Stack Management.",
+      "expected_output": "Rewritten description that removes the label prefix, is a complete sentence, and works 'reference' naturally into the text",
+      "expectations": [
+        "Removes the 'Reference -' label prefix",
+        "Writes a complete sentence",
+        "Is 200 characters or fewer",
+        "Works 'reference' or 'settings' naturally into the description",
+        "Does NOT use 'you can' or 'users can'"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Add a description for this troubleshooting page:\n\n---\napplies_to:\n  stack: ga\n---\n\n# Troubleshoot Elasticsearch cluster health [troubleshoot-cluster-health]\n\nWhen your cluster health turns yellow or red, follow these steps to identify the root cause and restore your cluster to green status.",
+      "expected_output": "Description starting with 'Troubleshooting guide for...'",
+      "expectations": [
+        "Description starts with 'Troubleshooting guide for' or similar troubleshooting-indicating phrase",
+        "Is 200 characters or fewer",
+        "Does NOT start with 'Troubleshooting -' as a label prefix",
+        "Mentions cluster health or related symptoms"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "This description uses Jinja2 variables which aren't parsed in frontmatter. Fix it:\n\n---\napplies_to:\n  stack: ga\n  serverless: ga\ndescription: Create visualizations in {{product.kibana}} using {{esql}} queries to explore your {{product.elasticsearch}} data.\n---\n\n# Create ES|QL visualizations [esql-visualizations]",
+      "expected_output": "Description rewritten with plain text instead of Jinja2 variables",
+      "expectations": [
+        "Replaces {{product.kibana}} with 'Kibana'",
+        "Replaces {{esql}} with 'ES|QL'",
+        "Replaces {{product.elasticsearch}} with 'Elasticsearch'",
+        "Keeps the description under 200 characters",
+        "Preserves the meaning of the original description"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a new `authoring/frontmatter-description` skill that generates or improves `description` fields in Elastic docs frontmatter
- Follows Google SEO best practices with Elastic-specific conventions: 200-char max, content-type-specific patterns, plain text only (no Jinja2 in frontmatter), action-oriented complete sentences
- Supports batch processing across directories with a summary report
- Includes 5 evals covering how-to, tutorial, reference rewrite, troubleshooting, and Jinja2 variable replacement scenarios

## Test plan

- [ ] Verify SKILL.md has valid frontmatter (name matches directory, valid SemVer)
- [ ] Verify evals.json has valid structure
- [ ] Run the skill on a page with no description and verify a correct one is generated
- [ ] Run the skill on a page with a bad description (label prefix, Jinja2 vars) and verify it's rewritten
- [ ] Verify generated descriptions respect the 200-character limit


Made with [Cursor](https://cursor.com)