### PR TITLE
Add frontmatter-audit skill (review)

### DIFF
--- a/skills/review/frontmatter-audit/SKILL.md
+++ b/skills/review/frontmatter-audit/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: frontmatter-audit
+version: 1.0.0
+description: Audit Elastic documentation files for frontmatter completeness and correctness. Checks applies_to, products, description, and navigation_title fields across a directory. Use when auditing docs metadata, checking frontmatter quality before publishing, or validating a batch of files.
+argument-hint: <file-or-directory>
+context: fork
+allowed-tools: Read, Grep, Glob
+sources:
+  - https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/reference
+  - https://developers.google.com/search/docs/appearance/snippet
+---
+<!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+or more contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright
+ownership. Elasticsearch B.V. licenses this file to you under
+the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. -->
+
+You are a frontmatter auditor for Elastic documentation. Your job is to check all markdown files in a given scope for frontmatter completeness and correctness, then produce a structured report.
+
+## Inputs
+
+`$ARGUMENTS` is a file path or directory to audit. If empty, ask the user what to audit.
+
+Before starting, ask the user to confirm these configuration defaults or provide overrides:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Required `applies_to` keys** | `stack`, `serverless` | Which keys must be present |
+| **Required `products`** | *(none)* | Which product IDs must appear (e.g., `kibana`) |
+| **Additional products allowed** | yes | Whether extra product IDs beyond the required ones are acceptable |
+
+## Required frontmatter elements
+
+Check each file for the following elements:
+
+### 1. `applies_to` (mandatory)
+
+Every page must have `applies_to` in its frontmatter. Verify:
+- Presence of all configured required keys
+- Valid lifecycle values: `preview`, `beta`, `ga`, `deprecated`, `removed`, `unavailable`
+- Valid version syntax if present (e.g., `ga 9.1`, `preview 9.0, ga 9.2`)
+- No mixed dimensions (stack/serverless keys should not be combined with deployment keys)
+
+```yaml
+applies_to:
+  stack: ga
+  serverless: ga
+```
+
+Flag files missing this element or missing required keys. Preserve existing version-specific values — don't normalize `ga 9.1` to just `ga`.
+
+### 2. `products` (mandatory)
+
+Must include the configured required product IDs. May include additional products.
+
+```yaml
+products:
+  - id: kibana
+```
+
+Flag files missing this element or missing required products. Don't remove existing additional products.
+
+### 3. `description` (mandatory)
+
+Validate against these rules:
+- Present and non-empty
+- Maximum 200 characters
+- Complete sentence (not a fragment or label)
+- No Jinja2 substitution variables (`{{kib}}`, `{{es}}`, `{{esql}}` — these aren't parsed in frontmatter)
+- No label prefixes ("Reference -", "Tutorial -", "Guide -")
+- Action-oriented (starts with a verb or content-type indicator)
+- No colons that could break YAML parsing
+
+### 4. `navigation_title` (recommended)
+
+Check if the H1 title exceeds ~50 characters. If so, flag that a `navigation_title` should be added.
+
+```yaml
+navigation_title: "Configure ML alerts"
+```
+
+### 5. `mapped_pages` (preserve)
+
+If present, don't flag or suggest changes. If absent, don't suggest adding it.
+
+## Execution
+
+1. **Glob** for all `.md` files in the specified scope
+2. **Read** the frontmatter of each file
+3. **Validate** each element against the rules above
+4. **Read** the H1 title to check length for `navigation_title`
+5. **Compile** the report
+
+## Report format
+
+```
+## Frontmatter audit: <scope>
+
+**Configuration:**
+- Required applies_to keys: stack, serverless
+- Required products: kibana
+- Files scanned: N
+
+### Issues found
+
+#### Missing `applies_to`
+| File | Issue |
+|------|-------|
+| path/to/file.md | Missing entirely |
+| path/to/other.md | Missing `serverless` key |
+
+#### Missing `products`
+| File | Issue |
+|------|-------|
+| path/to/file.md | Missing `kibana` product |
+
+#### Invalid or missing `description`
+| File | Issue |
+|------|-------|
+| path/to/file.md | Missing description |
+| path/to/other.md | Contains Jinja2 variables |
+| path/to/third.md | Exceeds 200 characters (247 chars) |
+
+#### Missing `navigation_title`
+| File | H1 length |
+|------|-----------|
+| path/to/file.md | 63 chars |
+
+### Summary
+
+- ✅ N files passed all checks
+- ❌ N files have issues
+  - N missing applies_to
+  - N missing products
+  - N invalid/missing description
+  - N missing navigation_title (recommended)
+```
+
+Group issues by type, not by file, so users can batch-fix related problems. Only include sections that have issues.

--- a/skills/review/frontmatter-audit/evals/evals.json
+++ b/skills/review/frontmatter-audit/evals/evals.json
@@ -1,0 +1,62 @@
+{
+  "skill_name": "frontmatter-audit",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Audit this file's frontmatter:\n\n---\napplies_to:\n  stack: ga\n---\n\n# Configure machine learning anomaly detection alerts in Kibana [configure-ml-alerts]\n\nSet up alerting rules for anomaly detection jobs.",
+      "expected_output": "Report flagging missing serverless key in applies_to, missing products, missing description, and recommending navigation_title due to long H1",
+      "expectations": [
+        "Flags the missing 'serverless' key in applies_to",
+        "Flags the missing 'products' element",
+        "Flags the missing 'description' field",
+        "Recommends adding navigation_title because the H1 exceeds ~50 characters",
+        "Produces a structured report"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Audit this file's frontmatter. Configuration: required applies_to keys are stack and serverless, required product is kibana.\n\n---\napplies_to:\n  stack: ga\n  serverless: ga\nproducts:\n  - id: kibana\ndescription: Create dashboards with visualizations, controls, and content. Configure settings, organize panels, and save custom analytics views.\n---\n\n# Create a dashboard [create-dashboard]\n\nCreate dashboards to visualize your data.",
+      "expected_output": "Report showing the file passes all checks",
+      "expectations": [
+        "Reports that applies_to has both required keys",
+        "Reports that products includes the required 'kibana'",
+        "Reports that description is present and valid",
+        "Does NOT flag navigation_title since the H1 is short enough",
+        "Does NOT report any issues for this file"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Audit frontmatter for this file:\n\n---\napplies_to:\n  stack: ga\n  serverless: ga\nproducts:\n  - id: kibana\ndescription: Reference - Kibana settings list. You can use these to configure {{product.kibana}} behavior and customize the UI for your needs and preferences.\n---\n\n# Advanced settings [advanced-settings]\n\nKibana advanced settings.",
+      "expected_output": "Report flagging the description for having a label prefix, containing Jinja2 variables, and possibly exceeding 200 characters",
+      "expectations": [
+        "Flags the 'Reference -' label prefix in the description",
+        "Flags the Jinja2 variable '{{product.kibana}}' in the description",
+        "Checks and reports whether the description exceeds 200 characters",
+        "Does NOT flag applies_to or products since they are correct"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Audit this file. It has a mapped_pages field:\n\n---\nmapped_pages:\n  - old-page.md\napplies_to:\n  stack: preview 9.0, ga 9.2\n  serverless: ga\nproducts:\n  - id: elasticsearch\ndescription: Index lifecycle management automates index transitions through phases to optimize storage and performance.\n---\n\n# ILM overview [ilm-overview]",
+      "expected_output": "Report that does NOT flag or modify mapped_pages, preserves the version-specific applies_to values, and passes most checks",
+      "expectations": [
+        "Does NOT flag or suggest changes to mapped_pages",
+        "Preserves the version-specific applies_to value 'preview 9.0, ga 9.2' without normalizing it",
+        "Validates the description as acceptable",
+        "Does NOT suggest the file has issues with applies_to syntax"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Audit this file's frontmatter:\n\n---\napplies_to:\n  stack: ga\n  deployment:\n    ece: ga\n---\n\n# Deploy Elasticsearch [deploy-es]\n\nDeploy Elasticsearch on your infrastructure.",
+      "expected_output": "Report flagging mixed dimensions in applies_to (stack and deployment keys combined)",
+      "expectations": [
+        "Flags the mixed dimensions: 'stack' and 'deployment' should not be combined at page level",
+        "Flags the missing 'description' field",
+        "Flags the missing 'products' element",
+        "Produces a structured report with these issues"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a new `review/frontmatter-audit` skill that audits Elastic docs files for frontmatter completeness and correctness
- Checks four elements: `applies_to` (mandatory keys, valid lifecycle/version syntax, no mixed dimensions), `products` (required IDs), `description` (200-char limit, no Jinja2, no label prefixes), and `navigation_title` (recommended for long H1s)
- Supports configurable requirements — user specifies which `applies_to` keys and `products` IDs are mandatory before the audit runs
- Produces a structured report grouped by issue type (not by file) for efficient batch fixing
- Uses `context: fork` (read-only review skill)
- Includes 5 evals covering missing fields, passing files, bad descriptions, mapped_pages preservation, and mixed-dimension detection

## Test plan

- [ ] Verify SKILL.md has valid frontmatter (name matches directory, valid SemVer)
- [ ] Verify evals.json has valid structure
- [ ] Run the skill on a directory with mixed-quality frontmatter and verify the report groups issues by type
- [ ] Verify the skill asks for configuration (required keys/products) before auditing
- [ ] Verify it preserves version-specific `applies_to` values and doesn't flag `mapped_pages`


Made with [Cursor](https://cursor.com)