### PR TITLE
Fix remote installer catalog parsing and improve public install docs

### DIFF
--- a/.github/scripts/generate-catalog.py
+++ b/.github/scripts/generate-catalog.py
@@ -26,7 +26,12 @@ SKILLS_DIR = Path("skills")
 OUT_DIR = Path("_site")
 
 REPO_URL = "https://github.com/elastic/elastic-docs-skills"
-INSTALL_CMD = "curl -fsSL https://raw.githubusercontent.com/elastic/elastic-docs-skills/main/install.sh | bash"
+INSTALL_COMMANDS = {
+    "Install": "curl -fsSL https://ela.st/docs-skills-install | bash",
+    "List": "curl -fsSL https://ela.st/docs-skills-install | bash -s -- --list",
+    "Update": "curl -fsSL https://ela.st/docs-skills-install | bash -s -- --update",
+    "Skills CLI": "npx --yes skills@latest add elastic/elastic-docs-skills -g -a claude-code",
+}
 
 CATEGORY_META = {
     "authoring": {
@@ -339,10 +344,26 @@ def render_html(categories: dict[str, list[dict]]) -> str:
 
     .install-banner {{
       margin-top: 2rem;
+      display: inline-flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.5rem;
+      width: min(100%, 900px);
+    }}
+
+    .install-row {{
       display: flex;
       align-items: center;
-      justify-content: center;
       gap: 0.5rem;
+      width: 100%;
+    }}
+
+    .cmd-label {{
+      min-width: 74px;
+      text-align: right;
+      color: var(--text-muted);
+      font-size: 0.8rem;
+      font-weight: 600;
     }}
 
     .install-banner code {{
@@ -354,6 +375,9 @@ def render_html(categories: dict[str, list[dict]]) -> str:
       font-size: 0.8rem;
       color: var(--text);
       user-select: all;
+      text-align: left;
+      flex: 1;
+      overflow-x: auto;
     }}
 
     .install-banner .copy-btn {{
@@ -496,10 +520,34 @@ def render_html(categories: dict[str, list[dict]]) -> str:
       </div>
     </div>
     <div class="install-banner">
-      <code id="install-cmd">{INSTALL_CMD}</code>
-      <button class="copy-btn" onclick="navigator.clipboard.writeText(document.getElementById('install-cmd').textContent).then(()=>{{this.innerHTML='<i data-feather=\\'check\\'></i>';feather.replace();setTimeout(()=>{{this.innerHTML='<i data-feather=\\'clipboard\\'></i>';feather.replace()}},2000)}})" title="Copy to clipboard">
-        <i data-feather="clipboard"></i>
-      </button>
+      <div class="install-row">
+        <span class="cmd-label">Install</span>
+        <code id="install-cmd">{" ".join(INSTALL_COMMANDS["Install"].split())}</code>
+        <button class="copy-btn" onclick="copyCmd('install-cmd', this)" title="Copy install command">
+          <i data-feather="clipboard"></i>
+        </button>
+      </div>
+      <div class="install-row">
+        <span class="cmd-label">List</span>
+        <code id="list-cmd">{" ".join(INSTALL_COMMANDS["List"].split())}</code>
+        <button class="copy-btn" onclick="copyCmd('list-cmd', this)" title="Copy list command">
+          <i data-feather="clipboard"></i>
+        </button>
+      </div>
+      <div class="install-row">
+        <span class="cmd-label">Update</span>
+        <code id="update-cmd">{" ".join(INSTALL_COMMANDS["Update"].split())}</code>
+        <button class="copy-btn" onclick="copyCmd('update-cmd', this)" title="Copy update command">
+          <i data-feather="clipboard"></i>
+        </button>
+      </div>
+      <div class="install-row">
+        <span class="cmd-label">Skills CLI</span>
+        <code id="skills-cli-cmd">{" ".join(INSTALL_COMMANDS["Skills CLI"].split())}</code>
+        <button class="copy-btn" onclick="copyCmd('skills-cli-cmd', this)" title="Copy skills CLI command">
+          <i data-feather="clipboard"></i>
+        </button>
+      </div>
     </div>
   </header>
 
@@ -511,7 +559,21 @@ def render_html(categories: dict[str, list[dict]]) -> str:
     Built from <a href="https://github.com/elastic/elastic-docs-skills">elastic/elastic-docs-skills</a> &middot; Auto-generated on each push to <code>main</code>
   </footer>
 
-  <script>feather.replace();</script>
+  <script>
+    function copyCmd(id, button) {{
+      const value = document.getElementById(id).textContent;
+      navigator.clipboard.writeText(value).then(() => {{
+        button.innerHTML = "<i data-feather='check'></i>";
+        feather.replace();
+        setTimeout(() => {{
+          button.innerHTML = "<i data-feather='clipboard'></i>";
+          feather.replace();
+        }}, 2000);
+      }});
+    }}
+
+    feather.replace();
+  </script>
 </body>
 </html>
 """

--- a/README.md
+++ b/README.md
@@ -6,7 +6,29 @@ Browse the catalog, pick the skills you need, and install them with a single com
 
 ## Quick start
 
-Clone the repository and run the interactive installer:
+Install directly from GitHub (no clone required):
+
+```bash
+curl -fsSL https://ela.st/docs-skills-install | bash
+```
+
+Optional flags:
+
+```bash
+# List available skills.
+curl -fsSL https://ela.st/docs-skills-install | bash -s -- --list
+
+# Install all skills.
+curl -fsSL https://ela.st/docs-skills-install | bash -s -- --all
+```
+
+Alternatively, install with the open `skills` CLI:
+
+```bash
+npx --yes skills@latest add elastic/elastic-docs-skills -g -a claude-code
+```
+
+If you plan to contribute, clone the repository and run locally:
 
 ```bash
 git clone https://github.com/elastic/elastic-docs-skills.git
@@ -67,10 +89,16 @@ Bump the `version` field in your `SKILL.md` frontmatter when making changes.
 ## Updating installed skills
 
 ```bash
-./install.sh --update
+curl -fsSL https://ela.st/docs-skills-install | bash -s -- --update
 ```
 
 This compares your installed skill versions against the catalog and updates any that have newer versions available.
+
+If you cloned this repository, you can also run:
+
+```bash
+./install.sh --update
+```
 
 ## CI validation
 

--- a/install.sh
+++ b/install.sh
@@ -23,9 +23,9 @@ set -euo pipefail
 # Zero external dependencies — uses Python 3 curses (ships with macOS/Linux)
 #
 # Usage:
-#   curl -sSL https://raw.githubusercontent.com/elastic/elastic-docs-skills/main/install.sh | bash
-#   curl -sSL https://raw.githubusercontent.com/elastic/elastic-docs-skills/main/install.sh | bash -s -- --list
-#   curl -sSL https://raw.githubusercontent.com/elastic/elastic-docs-skills/main/install.sh | bash -s -- --all
+#   curl -sSL https://ela.st/docs-skills-install | bash
+#   curl -sSL https://ela.st/docs-skills-install | bash -s -- --list
+#   curl -sSL https://ela.st/docs-skills-install | bash -s -- --all
 
 REPO="elastic/elastic-docs-skills"
 BRANCH="main"
@@ -115,12 +115,12 @@ pull_latest_local() {
 
 parse_field() {
   local file="$1" field="$2"
-  sed -n '/^---$/,/^---$/p' "$file" | grep "^${field}:" | head -1 | sed "s/^${field}: *//"
+  sed -n '/^---$/,/^---$/p' "$file" | grep "^${field}:" | head -1 | sed "s/^${field}: *//" || true
 }
 
 parse_field_from_content() {
   local content="$1" field="$2"
-  echo "$content" | sed -n '/^---$/,/^---$/p' | grep "^${field}:" | head -1 | sed "s/^${field}: *//"
+  echo "$content" | sed -n '/^---$/,/^---$/p' | grep "^${field}:" | head -1 | sed "s/^${field}: *//" || true
 }
 
 # Builds a TSV catalog: name\tversion\tcategory\tdescription\tpath
@@ -143,7 +143,7 @@ build_catalog_remote() {
     err "Failed to fetch repository tree from GitHub"; exit 1
   }
   local skill_paths
-  skill_paths=$(echo "$TREE_CACHE" | grep -o '"path":"skills/[^"]*SKILL\.md"' | sed 's/"path":"//;s/"//' | sort)
+  skill_paths=$(echo "$TREE_CACHE" | grep -oE '"path"[[:space:]]*:[[:space:]]*"skills/[^"]*SKILL\.md"' | sed -E 's/"path"[[:space:]]*:[[:space:]]*"//;s/"$//' | sort)
   [[ -z "$skill_paths" ]] && { err "No skills found in the remote catalog"; exit 1; }
 
   while IFS= read -r remote_path; do
@@ -196,7 +196,7 @@ install_one_remote() {
   else
     tree_response=$(curl -fsSL "${API_BASE}/git/trees/${BRANCH}?recursive=1" 2>/dev/null) || true
   fi
-  extra_files=$(echo "$tree_response" | grep -o "\"path\":\"${remote_dir}/[^\"]*\"" | sed 's/"path":"//;s/"//' | grep -v "SKILL\.md$" || true)
+  extra_files=$(echo "$tree_response" | grep -oE "\"path\"[[:space:]]*:[[:space:]]*\"${remote_dir}/[^\"]*\"" | sed -E 's/"path"[[:space:]]*:[[:space:]]*"//;s/"$//' | grep -v "SKILL\.md$" || true)
   while IFS= read -r extra_path; do
     [[ -z "$extra_path" ]] && continue
     local filename="${extra_path#"$remote_dir/"}"


### PR DESCRIPTION
## Summary
- fix remote catalog parsing in `install.sh` so curl-based modes (`--list`, `--all`, and `--update`) work reliably against GitHub API JSON output.
- harden frontmatter field parsing to tolerate missing keys in installed skills during `--update`.
- update public install surfaces to use `https://ela.st/docs-skills-install`, and add an alternative `npx skills add elastic/elastic-docs-skills` flow in both `README.md` and the generated GitHub Pages catalog header.

## Test plan
- [x] Run `curl -fsSL https://ela.st/docs-skills-install | bash -s -- --help`.
- [x] Run `curl -fsSL https://ela.st/docs-skills-install | bash -s -- --list` (validated failure in old script, then success with patched script in remote mode).
- [x] Run patched script in forced remote mode: `bash /tmp/elastic-install-test.sh --update` and verify update path succeeds.
- [x] Run `python3 .github/scripts/generate-catalog.py` and confirm generation succeeds.
- [x] Run lints for edited files via `ReadLints` and confirm no new errors.

Made with [Cursor](https://cursor.com)