### PR TITLE
Add llm-matrix-update skill for updating Security LLM benchmark table

### DIFF
--- a/skills/authoring/llm-matrix-update/SKILL.md
+++ b/skills/authoring/llm-matrix-update/SKILL.md
@@ -27,7 +27,7 @@ You are updating the Elastic Security LLM performance matrix. The user will prov
 
 ## Target file
 
-`solutions/security/ai/large-language-model-performance-matrix.md` in the `docs-content` repo.
+`solutions/security/ai/large-language-model-performance-matrix.md` in the `docs-content` repo. If the file moves, use the alternative location.
 
 ## Workflow
 
@@ -69,7 +69,7 @@ The file contains two tables with identical column headers:
 
 ### Row ordering
 
-Rows in each table are sorted by **Average Score descending** (highest first).
+Rows in each table are sorted by **Average Score** (highest first aka descending order).
 
 ### Row format
 

--- a/skills/authoring/llm-matrix-update/SKILL.md
+++ b/skills/authoring/llm-matrix-update/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: llm-matrix-update
+name: docs-llm-matrix-update
 version: 1.1.0
 description: Update the Elastic Security LLM performance matrix from screenshot or spreadsheet data. Use when the user provides new benchmark scores for the large language model support matrix, or asks to update LLM model scores in docs-content.
 argument-hint: <screenshot or table data>

--- a/skills/authoring/llm-matrix-update/SKILL.md
+++ b/skills/authoring/llm-matrix-update/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: llm-matrix-update
-version: 1.0.0
+version: 1.1.0
 description: Update the Elastic Security LLM performance matrix from screenshot or spreadsheet data. Use when the user provides new benchmark scores for the large language model support matrix, or asks to update LLM model scores in docs-content.
-allowed-tools: Read, Grep, Glob, Edit, Write
+argument-hint: <screenshot or table data>
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash
 sources:
   - https://www.elastic.co/docs/solutions/security/ai/large-language-model-performance-matrix
 ---
@@ -63,6 +64,8 @@ These rules are critical. The table uses specific conventions that must be prese
 The file contains two tables with identical column headers:
 
 | **Model** | **Alerts** | **Security Knowledge** | **{{esql}} Query Generation** | **Knowledge Base Retrieval** | **Attack Discovery** | **Automatic Migration** | **Average Score** |
+
+Note: `{{esql}}` is a docs-builder substitution variable that renders as "ES|QL" in the published page. Preserve it exactly as `{{esql}}` in the source file.
 
 - **Proprietary models**: Third-party provider models (section anchor: `_proprietary_models`)
 - **Open-source models**: Self-deployable models (section anchor: `_open_source_models`)

--- a/skills/authoring/llm-matrix-update/SKILL.md
+++ b/skills/authoring/llm-matrix-update/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: llm-matrix-update
+version: 1.0.0
+description: Update the Elastic Security LLM performance matrix from screenshot or spreadsheet data. Use when the user provides new benchmark scores for the large language model support matrix, or asks to update LLM model scores in docs-content.
+allowed-tools: Read, Grep, Glob, Edit, Write
+sources:
+  - https://www.elastic.co/docs/solutions/security/ai/large-language-model-performance-matrix
+---
+<!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+or more contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright
+ownership. Elasticsearch B.V. licenses this file to you under
+the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. -->
+
+You are updating the Elastic Security LLM performance matrix. The user will provide new benchmark data as a screenshot, spreadsheet, or table. Your job is to update the markdown file to match, preserving the exact formatting conventions.
+
+## Target file
+
+`solutions/security/ai/large-language-model-performance-matrix.md` in the `docs-content` repo.
+
+## Workflow
+
+1. **Read the current file** to understand its structure and formatting conventions.
+2. **Extract data** from the user-provided screenshot or spreadsheet. Carefully read every model name, score, and "Not Recommended" entry.
+3. **Compare** the new data against the current table. Identify:
+   - New models to add
+   - Removed models to delete
+   - Changed scores to update
+   - Reordering needed (tables are sorted by descending average score)
+4. **Apply changes** following the formatting rules strictly.
+5. **Push and open a PR** in the `docs-content` repo when the user requests it.
+
+## Formatting rules
+
+These rules are critical. The table uses specific conventions that must be preserved exactly.
+
+### Number formatting
+
+- Drop trailing zeros after the decimal point: `9.50` → `9.5`, `8.00` → `8`, `10.00` → `10`
+- Keep meaningful decimal digits: `8.42` stays `8.42`, `9.81` stays `9.81`
+- Examples: `7.30` → `7.3`, `9.00` → `9`, `6.96` stays `6.96`
+
+### Cell formatting
+
+- Model names are bold: `**Opus 4.6**`
+- The average score column is bold: `**9**`, `**8.19**`
+- All other score cells are plain numbers (not bold)
+- Failed tests use the exact string `Not recommended` (capital N, lowercase r)
+
+### Table structure
+
+The file contains two tables with identical column headers:
+
+| **Model** | **Alerts** | **Security Knowledge** | **{{esql}} Query Generation** | **Knowledge Base Retrieval** | **Attack Discovery** | **Automatic Migration** | **Average Score** |
+
+- **Proprietary models**: Third-party provider models (section anchor: `_proprietary_models`)
+- **Open-source models**: Self-deployable models (section anchor: `_open_source_models`)
+
+### Row ordering
+
+Rows in each table are sorted by **Average Score descending** (highest first).
+
+### Row format
+
+Each row follows this exact pattern:
+
+```
+| **Model Name** | score | score | score | score | score | score | **avg** |
+```
+
+Alignment row uses `:--- |` (left-aligned) for all columns.
+
+## Do not modify
+
+- YAML frontmatter
+- Page title, intro paragraph, or admonition
+- Section headings or anchor IDs
+- Section descriptions ("Models from third-party LLM providers." etc.)
+- Column headers or alignment row
+
+## Example transformation
+
+Source data: `Sonnet 4.5 | 8.60 | 7.60 | 7.70 | 7.23 | 8.00 | 10.00 | 8.19`
+
+Formatted row: `| **Sonnet 4.5** | 8.6 | 7.6 | 7.7 | 7.23 | 8 | 10 | **8.19** |`
+
+Source data: `Sonnet 4.6 | 9.30 | 9.50 | 8.40 | 7.45 | Not Recommended | 10.00 | 7.44`
+
+Formatted row: `| **Sonnet 4.6** | 9.3 | 9.5 | 8.4 | 7.45 | Not recommended | 10 | **7.44** |`

--- a/skills/authoring/llm-matrix-update/evals/evals.json
+++ b/skills/authoring/llm-matrix-update/evals/evals.json
@@ -1,0 +1,53 @@
+{
+  "skill_name": "llm-matrix-update",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Update the LLM performance matrix. Here is the new data:\n\nModel | Alert Analysis | Security Knowledge | ES|QL Generation | Knowledge Base Retrieval | Attack Discovery | Automatic Migration | Overall Average\nModelX | 9.50 | 8.00 | 7.30 | 6.00 | 8.50 | 10.00 | 8.22\nModelY | 7.80 | 6.20 | 4.40 | 5.71 | Not Recommended | 9.81 | 5.65",
+      "expected_output": "Updates the proprietary models table with two rows, formatted correctly with trailing zeros dropped and proper bold/ordering",
+      "expectations": [
+        "Reads the current file before making edits",
+        "Drops trailing zeros: 9.50 becomes 9.5, 8.00 becomes 8, 7.30 becomes 7.3, 6.00 becomes 6, 10.00 becomes 10",
+        "Formats model names in bold: **ModelX**, **ModelY**",
+        "Formats average scores in bold: **8.22**, **5.65**",
+        "Uses 'Not recommended' (capital N, lowercase r) not 'Not Recommended'",
+        "Orders rows by average score descending (ModelX before ModelY)"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I have updated benchmark scores. The proprietary table should now include a new model called 'Gemini 3.0' with scores: Alert Analysis 8.20, Security Knowledge 7.10, ES|QL Generation 5.50, Knowledge Base Retrieval 6.00, Attack Discovery 7.00, Automatic Migration 8.30, Overall Average 7.02. All existing models stay the same.",
+      "expected_output": "Adds one new row for Gemini 3.0 in the correct sorted position without modifying existing rows",
+      "expectations": [
+        "Reads the current file to see existing rows",
+        "Adds a single new row for Gemini 3.0",
+        "Does not modify any existing model rows",
+        "Inserts the row at the correct position based on descending average score",
+        "Formats as: | **Gemini 3.0** | 8.2 | 7.1 | 5.5 | 6 | 7 | 8.3 | **7.02** |"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Here is the new OSS model data. Replace the open-source models table:\n\nGPT OSS 120B | 7.60 | 3.70 | 5.50 | 6.00 | 3.50 | 9.70 | 6.00\nGPT OSS 20b | 8.20 | 1.50 | 2.50 | Not Recommended | Not Recommended | Not Recommended | 2.03\nLlama 4 70B | 6.80 | 5.20 | 4.10 | 5.00 | Not Recommended | 7.90 | 4.83",
+      "expected_output": "Replaces the open-source models table with three rows, adding the new Llama 4 70B model in the correct sorted position",
+      "expectations": [
+        "Only modifies the open-source models table, not the proprietary table",
+        "Does not modify the frontmatter, headings, or intro content",
+        "Orders by average score descending: GPT OSS 120B (6.00), Llama 4 70B (4.83), GPT OSS 20b (2.03)",
+        "Drops trailing zeros consistently across all rows",
+        "Uses 'Not recommended' (capital N, lowercase r) for all failed entries"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "The latest benchmarks show that GPT 5.1 has been removed from testing. Remove it from the LLM matrix. All other models stay the same.",
+      "expected_output": "Removes only the GPT 5.1 row from the proprietary models table without changing anything else",
+      "expectations": [
+        "Removes exactly one row: GPT 5.1",
+        "Does not modify any other rows",
+        "Does not change the open-source models table",
+        "Does not modify frontmatter, headings, or descriptions"
+      ]
+    }
+  ]
+}

--- a/skills/authoring/llm-matrix-update/evals/evals.json
+++ b/skills/authoring/llm-matrix-update/evals/evals.json
@@ -3,7 +3,7 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Update the LLM performance matrix. Here is the new data:\n\nModel | Alert Analysis | Security Knowledge | ES|QL Generation | Knowledge Base Retrieval | Attack Discovery | Automatic Migration | Overall Average\nModelX | 9.50 | 8.00 | 7.30 | 6.00 | 8.50 | 10.00 | 8.22\nModelY | 7.80 | 6.20 | 4.40 | 5.71 | Not Recommended | 9.81 | 5.65",
+      "prompt": "Update the LLM performance matrix. Replace the entire proprietary models table with the following data:\n\nModel | Alert Analysis | Security Knowledge | ES|QL Generation | Knowledge Base Retrieval | Attack Discovery | Automatic Migration | Overall Average\nModelX | 9.50 | 8.00 | 7.30 | 6.00 | 8.50 | 10.00 | 8.22\nModelY | 7.80 | 6.20 | 4.40 | 5.71 | Not Recommended | 9.81 | 5.65",
       "expected_output": "Updates the proprietary models table with two rows, formatted correctly with trailing zeros dropped and proper bold/ordering",
       "expectations": [
         "Reads the current file before making edits",
@@ -51,3 +51,4 @@
     }
   ]
 }
+ 

--- a/skills/authoring/llm-matrix-update/evals/evals.json
+++ b/skills/authoring/llm-matrix-update/evals/evals.json
@@ -3,8 +3,8 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Update the LLM performance matrix. Replace the entire proprietary models table with the following data:\n\nModel | Alert Analysis | Security Knowledge | ES|QL Generation | Knowledge Base Retrieval | Attack Discovery | Automatic Migration | Overall Average\nModelX | 9.50 | 8.00 | 7.30 | 6.00 | 8.50 | 10.00 | 8.22\nModelY | 7.80 | 6.20 | 4.40 | 5.71 | Not Recommended | 9.81 | 5.65",
-      "expected_output": "Updates the proprietary models table with two rows, formatted correctly with trailing zeros dropped and proper bold/ordering",
+      "prompt": "Update the LLM performance matrix. Replace the entire table with the new user-input data.",
+      "expected_output": "Updates the proprietary models table based on the input data, formatted correctly with trailing zeros dropped and proper bold/ordering",
       "expectations": [
         "Reads the current file before making edits",
         "Drops trailing zeros: 9.50 becomes 9.5, 8.00 becomes 8, 7.30 becomes 7.3, 6.00 becomes 6, 10.00 becomes 10",


### PR DESCRIPTION
## Summary

New authoring skill that helps update the LLM performance matrix in docs-content from screenshot or spreadsheet data.

- Reads the current markdown file to understand formatting conventions
- Extracts data from user-provided screenshots or spreadsheets
- Applies strict formatting rules: trailing zero removal, bold model names and averages, "Not recommended" casing, descending sort by average score
- Preserves all non-table content (frontmatter, headings, descriptions)
- Includes 4 evals covering add, update, remove, and replace scenarios

## Test plan

- [x] CI validates frontmatter schema (name, version, description)
- [x] CI validates evals.json structure
- [x] Skill name matches directory name (`llm-matrix-update`)
- [x] Version is valid SemVer (`1.0.0`)

## Gen AI disclosure
Used Claude 4.6 with Cursor