### PR TITLE
Fix plugin.json version check to require strictly greater version

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -141,12 +141,20 @@ jobs:
             exit 1
           fi
 
-          # On PRs: require plugin.json version bump when skills change
+          # On PRs: require plugin.json version to be strictly greater than base when skills change
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             base_version=$(git show "origin/${{ github.base_ref }}:.claude-plugin/plugin.json" 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('version','0.0.0'))" 2>/dev/null || echo "0.0.0")
             head_version=$(python3 -c "import json; print(json.load(open('.claude-plugin/plugin.json')).get('version','0.0.0'))" 2>/dev/null || echo "0.0.0")
-            if [[ "$base_version" == "$head_version" ]]; then
-              echo "::error file=.claude-plugin/plugin.json::Skills changed but plugin.json version ($head_version) was not bumped. Please update the version field."
+            # Use Python for semver comparison to avoid string ordering issues
+            is_bumped=$(python3 -c "
+          import sys
+          def parse(v):
+              try: return tuple(int(x) for x in v.split('.'))
+              except: return (0, 0, 0)
+          print('yes' if parse('$head_version') > parse('$base_version') else 'no')
+          ")
+            if [[ "$is_bumped" != "yes" ]]; then
+              echo "::error file=.claude-plugin/plugin.json::Skills changed but plugin.json version was not bumped (base: $base_version, head: $head_version). Please increment the version field."
               ((errors++))
             else
               echo "plugin.json version bumped: $base_version → $head_version ✓"


### PR DESCRIPTION
## Summary

Fixes a gap in the plugin manifest version check introduced in #43.

## The bug

PR #42 slipped through without bumping `plugin.json` because its branch predates #43 merging and therefore has no `.claude-plugin/plugin.json`. The old check compared versions with `==`:

- `base_version` → `1.0.0` (from `main`)
- `head_version` → `0.0.0` (fallback — file missing on PR branch)

Since `1.0.0 ≠ 0.0.0`, the check passed — for the wrong reason.

## The fix

Switch from an equality check (`base == head` → fail) to a strict semver greater-than comparison (`head > base` → pass). This correctly rejects:
- Missing `plugin.json` on the PR branch (falls back to `0.0.0`)
- Same version as base (not bumped)
- A lower version than base (shouldn't happen, but now caught)

🤖 Generated with [Claude Code](https://claude.com/claude-code)