### PR TITLE
Update Elastic docs review skills

### DIFF
--- a/skills/authoring/applies-to-tagging/SKILL.md
+++ b/skills/authoring/applies-to-tagging/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: docs-applies-to-tagging
-version: 1.0.4
+version: 1.1.0
 description: Validate and generate applies_to tags in Elastic documentation. Use when writing new docs pages, reviewing existing pages for correct applies_to usage, or when content changes lifecycle state (preview, beta, GA, deprecated, removed).
 argument-hint: <file-or-directory>
 context: fork
-allowed-tools: Read, Grep, Glob, Edit
+allowed-tools: Read, Grep, Glob, Edit, CallMcpTool, WebFetch
 sources:
-  - https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/applies
+  - https://elastic.github.io/docs-builder/syntax/applies/
   - https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/reference
   - https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/guidelines
   - https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/badge-placement
@@ -53,7 +53,7 @@ applies_to:
 **Section-level** (after a heading — applies to everything between that heading and the next heading of the same or higher level):
 ````markdown
 ```{applies_to}
-stack: ga 9.1
+stack: ga 9.1+
 serverless: unavailable
 ```
 ````
@@ -61,14 +61,14 @@ serverless: unavailable
 The `yaml {applies_to}` variant is also supported to enable YAML syntax highlighting in editors:
 ````markdown
 ```yaml {applies_to}
-stack: ga 9.1
+stack: ga 9.1+
 serverless: unavailable
 ```
 ````
 
 **Inline**:
 ```markdown
-Some text {applies_to}`stack: ga 9.1` more text.
+Some text {applies_to}`stack: ga 9.1+` more text.
 ```
 
 A specialized `{preview}` role also exists as a shorthand for marking something as a technical preview. It takes the version as its argument:
@@ -80,7 +80,7 @@ Feature name {preview}`9.1`
 **Admonitions** (via `:applies_to:` directive option):
 ```markdown
 :::{note}
-:applies_to: stack: ga 9.1
+:applies_to: stack: ga 9.1+
 This note applies only to Stack 9.1+.
 :::
 ```
@@ -88,12 +88,12 @@ This note applies only to Stack 9.1+.
 **Dropdowns** (via `:applies_to:` directive option):
 ```markdown
 :::{dropdown} Dropdown title
-:applies_to: stack: ga 9.0
+:applies_to: stack: ga 9.0+
 Dropdown content here.
 :::
 ```
 
-For admonitions and dropdowns, you can also use object notation for multiple keys: `:applies_to: { ece:, ess: }` or JSON: `:applies_to: {"stack": "ga 9.2", "serverless": "ga"}`.
+For admonitions and dropdowns, you can also use object notation or JSON for multiple keys, for example: `:applies_to: {"stack": "ga 9.2+", "serverless": "ga"}`.
 
 ### Keys
 
@@ -102,14 +102,14 @@ Use only **one dimension** at page level:
 | Dimension | Keys |
 |-----------|------|
 | Stack/Serverless | `stack`, `serverless` (subkeys: `security`, `elasticsearch`, `observability`) |
-| Deployment | `deployment` (subkeys: `ece`, `eck`, `ess`, `self`), `serverless` |
+| Deployment | `deployment` (subkeys: `ech`, `ece`, `eck`, `self`), `serverless` |
 | Product | `product` (subkeys: APM agents, EDOT SDKs, tools — see [full key reference](https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/reference)) |
+
+Use `ech` for Elastic Cloud Hosted. `ess` is a deprecated alias and should not be generated in new tags. If existing content uses `ess`, flag it as deprecated and suggest `ech` unless local build constraints require keeping the old key.
 
 ### Lifecycle states
 
 `preview`, `beta`, `ga`, `deprecated`, `removed`, `unavailable`
-
-Avoid using `all` — instead, explicitly list the applicable keys and lifecycles.
 
 ### Version formats (versioned products only)
 
@@ -120,6 +120,13 @@ Avoid using `all` — instead, explicitly list the applicable keys and lifecycle
 | Exact | `=x.x` or `=x.x.x` | `beta =9.1` | 9.1 |
 
 Unversioned products (serverless) use lifecycle only: `serverless: ga`.
+
+When generating new tags, make version intent explicit:
+- Use `x.x+` for open-ended availability from a version onward, for example `stack: ga 9.1+`.
+- Use `=x.x` for exactly one minor version, for example `stack: preview =9.0`.
+- Use `x.x-y.y` for an inclusive range, for example `stack: beta 9.1-9.2`.
+- Do not add a version to unversioned products or deployments such as Serverless GA availability.
+- Do not treat `ga 9.1` as invalid, because docs-builder accepts it, but prefer `ga 9.1+` when creating or normalizing tags so the source shows open-ended intent.
 
 **Important version display notes:**
 - Versions always display as **Major.Minor** (e.g., `9.1`) in badges, regardless of whether you specify patch versions in the source.
@@ -156,10 +163,13 @@ When validating, check for these errors:
 2. **Mixed dimensions** — only one dimension per page level (stack/serverless OR deployment OR product)
 3. **One version per lifecycle** — `ga 9.2, ga 9.3` is invalid
 4. **One open-ended per key** — only one `+` lifecycle allowed per key
-5. **Invalid range order** — first version must be less than or equal to second
-6. **No overlapping ranges** — `ga 9.2+, beta 9.0-9.2` is invalid (9.2 overlaps)
-7. **Heading annotations** — section-level only, never use inline annotations with headings
-8. **Version numbers in prose** — never write versions in text next to applies_to badges
+5. **Invalid exact syntax** — exact versions must use `=x.x` or `=x.x.x`, not a bare version that is meant to be exact
+6. **Invalid range order** — the first version in `x.x-y.y` must be less than or equal to the second
+7. **Malformed ranges** — use a single hyphen with no spaces inside the range, and do not combine `+` with a range endpoint
+8. **No overlapping ranges** — `ga 9.2+, beta 9.0-9.2` is invalid because 9.2 overlaps
+9. **Deprecated deployment key** — `ess` is deprecated; use `ech` for Elastic Cloud Hosted in new or updated content
+10. **Heading annotations** — section-level only, never use inline annotations with headings
+11. **Version numbers in prose** — never write versions in text next to applies_to badges
 
 ## Guidelines for tagging
 
@@ -171,7 +181,7 @@ When validating, check for these errors:
 **DO NOT tag when:**
 - Fixing typos, formatting, or information architecture (no feature change)
 - The section's applicability is already established by a parent tag
-- Adding GA features to unversioned products (all users have latest)
+- Adding GA features to unversioned products where the page-level lifecycle already covers the content
 
 **Badge placement:**
 - Page level: frontmatter only
@@ -203,7 +213,7 @@ applies_to:
 **Progressive GA with version history:**
 ```yaml
 applies_to:
-  stack: preview 9.0, ga 9.2
+  stack: preview =9.0, ga 9.2+
   serverless: ga
 ```
 
@@ -222,14 +232,14 @@ applies_to:
   deployment:
     ece: ga 4.0
     eck: ga 3.0
-    ess: ga
+    ech: ga
     self: ga
 ```
 
 **Feature deprecated then removed:**
 ```yaml
 applies_to:
-  stack: deprecated 9.1, removed 9.4
+  stack: deprecated 9.1-9.3, removed 9.4+
 ```
 
 **Section unavailable in serverless:**
@@ -257,7 +267,7 @@ serverless: unavailable
 
 For exhaustive key lists, advanced scenarios, and badge placement details, fetch these URLs:
 
-- [Syntax reference](https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/applies)
+- [Syntax reference](https://elastic.github.io/docs-builder/syntax/applies/)
 - [Full key reference](https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/reference)
 - [Guidelines](https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/guidelines)
 - [Badge placement](https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/badge-placement)

--- a/skills/authoring/applies-to-tagging/evals/evals.json
+++ b/skills/authoring/applies-to-tagging/evals/evals.json
@@ -4,10 +4,10 @@
     {
       "id": 1,
       "prompt": "I just added a new page about machine learning anomaly detection that's available in both stack (since 8.15) and serverless elasticsearch. Can you add the right applies_to frontmatter?",
-      "expected_output": "Correct YAML frontmatter with applies_to containing stack: ga 8.15 and serverless with elasticsearch subkey set to ga",
+      "expected_output": "Correct YAML frontmatter with applies_to containing stack: ga 8.15+ and serverless with elasticsearch subkey set to ga",
       "expectations": [
         "The output includes applies_to in YAML frontmatter format",
-        "stack is set to ga with version 8.15",
+        "stack is set to ga with version 8.15+ to show open-ended availability",
         "serverless uses the elasticsearch subkey set to ga",
         "No mixed dimensions are used (stack/serverless only)"
       ]
@@ -15,10 +15,11 @@
     {
       "id": 2,
       "prompt": "Can you check the applies_to tags in this file? The frontmatter says:\n---\napplies_to:\n  stack: ga 9.2, ga 9.3\n  serverless: ga\n  deployment:\n    ess: ga\n---",
-      "expected_output": "Report identifying two validation errors: duplicate lifecycle for same key (ga 9.2, ga 9.3) and mixed dimensions (stack/serverless mixed with deployment)",
+      "expected_output": "Report identifying duplicate lifecycle for the same key, mixed dimensions, and deprecated ess usage",
       "expectations": [
         "Flags the duplicate ga lifecycle as invalid (one version per lifecycle rule)",
         "Flags mixed dimensions (stack/serverless cannot be combined with deployment at page level)",
+        "Flags 'ess' as deprecated and suggests 'ech' for Elastic Cloud Hosted",
         "Does not flag serverless: ga as an error"
       ]
     },
@@ -42,6 +43,17 @@
         "Does NOT flag the serverless subkeys as errors — elasticsearch and observability are valid project types",
         "Does NOT suggest changes to a correctly formed applies_to block",
         "Confirms the frontmatter is valid or produces a clean report with no issues"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Check these applies_to tags:\n---\napplies_to:\n  deployment:\n    ess: ga\n    eck: ga 3.0+\n  stack: beta 9.3-9.1\n---",
+      "expected_output": "Report identifying mixed dimensions, deprecated ess key with suggestion to use ech, and invalid range order for beta 9.3-9.1",
+      "expectations": [
+        "Flags mixed dimensions because deployment and stack keys are combined at page level",
+        "Flags 'ess' as deprecated and suggests 'ech' for Elastic Cloud Hosted",
+        "Flags the range '9.3-9.1' because the start version is greater than the end version",
+        "Does NOT flag 'eck: ga 3.0+' as invalid because open-ended version syntax is valid"
       ]
     }
   ]

--- a/skills/authoring/content-type-checker/SKILL.md
+++ b/skills/authoring/content-type-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-content-type-checker
-version: 2.0.1
+version: 2.1.0
 description: Check a docs-content page against Elastic content type guidelines (overview, how-to, tutorial, troubleshooting, changelog). Use when the user asks to check content type compliance, validate page structure, or review a doc against content type standards.
 argument-hint: <file-or-directory>
 context: fork
@@ -54,6 +54,7 @@ If no `type` field is present, infer the content type from the page structure an
 ### Preferred: elastic-docs MCP
 
 Use the `elastic-docs` MCP server's `get_document_by_url` tool to fetch the guidelines page, with `includeBody` set to `true`. Pass the guidelines URL from the table below.
+Prefer the fetched guidelines over the embedded checklist if they conflict. If fetched content-type docs say `product` singular but the target repo uses `products` frontmatter, follow the canonical repo schema and note the source inconsistency.
 
 ### Fallback: WebFetch
 
@@ -72,6 +73,56 @@ Use the fetched content to evaluate the page against the required elements, reco
 ## Step 3: Evaluate against guidelines
 
 Check the page against the fetched content type guidelines. For each required element, check whether it's present and correct. For best practices, note any violations.
+
+Use these current checklists as the minimum review criteria:
+
+### Shared frontmatter and metadata
+
+- **Filename**: Matches the content type pattern when one exists.
+- **Frontmatter**: Includes `applies_to`, `description`, and the repo's canonical product metadata field. In docs-content, use `products`, not `product`.
+- **Title**: Matches the content type intent, uses sentence case, and is specific enough for search and navigation.
+- **Introduction**: Helps readers confirm that the page matches their goal.
+
+### Overview
+
+- **Purpose**: Explains a single concept, feature, product, or capability.
+- **Required content**: Answers what it is, how it works, and why it matters.
+- **Recommended content**: Includes use cases or examples, how-it-works content, next steps, and related pages when useful.
+- **Anti-patterns**: Does not include long procedures, reference tables that belong elsewhere, or duplicated how-to content.
+
+### How-to guide
+
+- **Purpose**: Helps users complete one self-contained task.
+- **Required content**: Includes an action-verb title, a short outcome-focused introduction, a **Before you begin** or requirements section, numbered steps, and success checkpoints.
+- **Recommended content**: Includes next steps and related pages when useful.
+- **Anti-patterns**: Does not teach broad concepts, chain many tasks together, exceed roughly 10 overall steps without reason, or omit verification for important actions.
+
+### Tutorial
+
+- **Purpose**: Provides a hands-on learning experience that chains related tasks toward a meaningful outcome.
+- **Required content**: Includes learning objectives, audience or skill expectations when useful, prerequisites and setup, instructional steps, checkpoints or results, code annotations when code is central, next steps, and related pages.
+- **Recommended content**: Uses progressive disclosure, realistic examples, and verification steps throughout.
+- **Anti-patterns**: Does not behave like a single narrow recipe, a reference page, or a long conceptual overview without practice.
+
+### Troubleshooting
+
+- **Purpose**: Helps users resolve one specific, repeatable problem.
+- **Required content**: Includes a problem-focused title, a **Symptoms** section, and a **Resolution** section.
+- **Symptoms**: Describes user-visible behavior only, includes exact error messages when available, and avoids causes.
+- **Resolution**: Provides ordered, prescriptive steps from most common to least common fix, with minimal configuration examples when useful.
+- **Optional content**: Includes **Diagnosis** only when the same symptom can have multiple causes, **Best practices** only for prevention directly tied to the problem, and **Resources** only for supplementary reading.
+- **Anti-patterns**: Does not use a generic "Troubleshooting X" title for a dedicated issue page, mix unrelated problems, or put long explanations before the fix.
+
+### Changelog
+
+- **Purpose**: Describes one user-facing product change for release notes generation.
+- **Required content**: Includes `title`, `type`, and `products`.
+- **Title**: Uses present tense, starts with an action verb, focuses on user impact, and stays under 80 characters.
+- **Description**: Adds context only when needed, focuses on user value, and stays under 600 characters.
+- **Impact and action**: Required for breaking changes and recommended for deprecations and known issues.
+- **Anti-patterns**: Does not focus on implementation details, internal references, vague summaries, or duplicated title text.
+
+When the inferred type differs from the declared `type`, report the mismatch first, then evaluate against the type that best matches the page's actual purpose.
 
 ## Step 4: Generate report
 

--- a/skills/authoring/content-type-checker/evals/evals.json
+++ b/skills/authoring/content-type-checker/evals/evals.json
@@ -15,11 +15,12 @@
     {
       "id": 2,
       "prompt": "I wrote a troubleshooting page for common Kibana dashboard errors. Can you check if it follows the right structure? The file is at docs/troubleshooting/kibana-dashboards.md",
-      "expected_output": "Evaluation against troubleshooting content type guidelines, checking for problem/cause/solution structure, symptoms, and prerequisites",
+      "expected_output": "Evaluation against troubleshooting content type guidelines, checking for a problem-focused title, Symptoms section, Resolution section, and whether diagnosis or prerequisites are only included when needed",
       "expectations": [
         "Attempts to read the file or asks for its content",
         "References the troubleshooting content type guidelines",
-        "Checks for problem-cause-solution structure",
+        "Checks for required Symptoms and Resolution sections",
+        "Flags generic wayfinding titles if the page is meant to resolve one dedicated problem",
         "Generates a report with required elements checklist"
       ]
     },
@@ -32,6 +33,28 @@
         "Recognizes the prerequisite section as correct structure",
         "Recognizes the numbered steps as proper how-to format",
         "Does NOT recommend converting it to a different content type"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Check this overview page against the content type guidelines:\n\n---\ntype: overview\nproducts:\n  - id: elasticsearch\ndescription: Learn how index lifecycle management automates index transitions to optimize storage and performance.\napplies_to:\n  stack: ga\n---\n\n# Index lifecycle management\n\nIndex lifecycle management automates transitions through lifecycle phases.\n\n## Create a policy\n\n1. Open **Stack Management**.\n2. Click **Create policy**.",
+      "expected_output": "Report that the declared overview contains how-to content and should move step-by-step instructions to a how-to guide or link to one",
+      "expectations": [
+        "Recognizes the declared type as overview",
+        "Flags numbered procedural steps as an overview anti-pattern",
+        "Checks shared frontmatter using products, not product singular",
+        "Suggests keeping the overview conceptual and linking to a how-to guide"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Check this changelog YAML against the content type guidelines:\n\ntitle: Bug fixes\ntype: breaking-change\nproducts:\n  - product: elasticsearch\n    target: 9.2.0\ndescription: Refactored internals. See PR #123.\n",
+      "expected_output": "Report that the changelog title is too vague, the description focuses on implementation/internal references, and breaking changes need impact and action fields",
+      "expectations": [
+        "Checks required changelog fields: title, type, and products",
+        "Flags the vague title and recommends a user-impact-focused present-tense action verb",
+        "Flags implementation-focused description and internal PR-only context",
+        "Flags missing impact and action fields for a breaking change"
       ]
     }
   ]

--- a/skills/review/docs-check-style/SKILL.md
+++ b/skills/review/docs-check-style/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: docs-check-style
-version: 1.0.5
+version: 1.1.0
 description: Check documentation for Elastic style guide compliance using Vale linter output and style rules. Use when writing, editing, or reviewing docs to catch voice, tone, grammar, formatting, accessibility, and word choice issues.
 argument-hint: <file-or-directory>
 context: fork
-allowed-tools: Read, Grep, Glob, Bash(vale *), WebFetch
+allowed-tools: Read, Grep, Glob, Bash(vale *), CallMcpTool, WebFetch
 sources:
   - https://www.elastic.co/docs/contribute-docs/style-guide
   - https://www.elastic.co/docs/contribute-docs/style-guide/voice-tone
@@ -37,7 +37,11 @@ You are a style reviewer for Elastic documentation. Your job is to check docs ag
 
 `$ARGUMENTS` is the file or directory to check. If empty, ask the user what to review.
 
-## Step 1: Run Vale
+## Step 1: Refresh style guidance
+
+Use the Elastic docs MCP `get_document_by_url` tool with `includeBody: true` to fetch the style guide pages listed in `sources`. If the MCP is unavailable, fetch the `.md` page URLs directly. Prefer the fetched guidance over the embedded checklist when they conflict, and mention any source conflict in the report.
+
+## Step 2: Run Vale
 
 Try the Vale MCP tool first (`vale_lint`). If unavailable, fall back to the CLI:
 
@@ -47,11 +51,11 @@ vale --output=line $ARGUMENTS
 
 If Vale is not installed, skip this step and note it in your report. Proceed with manual review.
 
-## Step 2: Read the document(s)
+## Step 3: Read the document(s)
 
 Glob for `.md` files in `$ARGUMENTS` (or read the single file). Read each file fully.
 
-## Step 3: Review against style rules
+## Step 4: Review against style rules
 
 Check every document against the rules below. Categorize each issue by area.
 
@@ -138,9 +142,13 @@ Also flag Latin abbreviations: replace "e.g." with "for example," "i.e." with "t
 - **Italic**: New terms and concepts, Elastic documentation resource titles.
 - **Monospace**: API endpoints, class names, code, commands, config settings, data types, directories, env vars, error messages, field names, function names, index names, parameters, process names, property names, role names, variables.
 - **Numbers**: Write out 1–9 in prose, numerals for 10+. Use numerals in tables, for decimals, dimensions, percentages. Separate large numbers with commas (1,234,567).
+- **Dates and times**: Use `Month DD, YYYY` for dates. Use 12-hour time with uppercase `AM`/`PM`. Use UTC as the primary time zone, or include UTC with local time when needed. Avoid relative terms such as "last month," "recently," and "currently."
 - **Lists**: Minimum two items. Parallel structure. Capitalize first letter. No periods unless complete sentences. Introduce with a heading, sentence, or fragment ending with a colon.
 - **Paragraphs**: Keep under seven lines.
 - **Line spacing**: Single line break between elements.
+- **Admonitions**: Use notes, tips, warnings, important blocks, and plain admonitions for their documented purpose. Do not stack admonitions, overuse them, or use regular admonitions for prerequisites when a plain requirements admonition fits better.
+- **Code samples**: Use consistent indentation, syntax highlighting, runnable examples when possible, and short comments before the code they explain. For JSON, use footnotes only when needed because footnotes are less accessible.
+- **Sensitive information**: Flag screenshots, examples, logs, tokens, hostnames, IPs, internal links, customer data, and secrets that need redaction or replacement with documentation-safe placeholders.
 
 ### Accessibility
 
@@ -162,12 +170,15 @@ Also flag Latin abbreviations: replace "e.g." with "for example," "i.e." with "t
 - **Keys**: "Press Enter" / "Press Command+Alt+L."
 - **Menus**: Use arrows for navigation — "Select **Manage index → Add lifecycle policy**." Do **not** use the verbs "open" or "close" for menus; use "From the menu,..." instead. Refer to the element as "menu" — not "dropdown menu" or "dropdown list."
 - **Icons**: Reference by tooltip text, include inline icon. Avoid parentheses around icons.
+- **Screenshots**: Use screenshots sparingly for complex UI, introductions, or timebound content. Check that screenshots use a consistent aspect ratio, 100% zoom, only essential UI, a screenshot border when appropriate, accessible alt text, and no sensitive information.
 - **Procedures**: 5–9 steps. Focus on use cases, not piece-by-piece UI description. Eliminate obvious steps.
 - **Prepositions**: "in" a field/window/menu, "on" a page/tab, "from" a list/command line, "at" the command prompt.
 
+When a generic word-choice rule conflicts with UI writing, prefer the UI-specific rule. For example, `click` is correct for action buttons and icons, while `select` is correct for choices such as tabs, checkboxes, radio buttons, and dropdown options.
+
 ---
 
-## Step 4: Generate the report
+## Step 5: Generate the report
 
 Present findings as a structured report. Group issues by area. For each issue:
 

--- a/skills/review/docs-check-style/evals/evals.json
+++ b/skills/review/docs-check-style/evals/evals.json
@@ -39,6 +39,18 @@
         "Does NOT flag 'enter' as a word choice issue (it's the preferred verb for text input)",
         "Reports the paragraph as clean or flags only minor issues"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "Check this docs snippet for style:\n\n\"Recently, the API started returning errors at 16:30 PST. Use 10.1.2.3 and https://internal.example.com/token in the example below. The screenshot has no alt text.\"",
+      "expected_output": "Flags relative time wording, time zone/time format issues, sensitive placeholder data, directional language, and missing alt text",
+      "expectations": [
+        "Flags 'Recently' as a relative time reference",
+        "Flags 24-hour time and seasonal time zone usage, and suggests a 12-hour time with UTC context",
+        "Flags IP address, internal URL, and token-like example as sensitive information needing redaction or documentation-safe placeholders",
+        "Flags 'below' as directional language",
+        "Flags missing alt text for the screenshot"
+      ]
     }
   ]
 }

--- a/skills/review/frontmatter-audit/SKILL.md
+++ b/skills/review/frontmatter-audit/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: docs-frontmatter-audit
-version: 1.0.1
+version: 1.1.0
 description: Audit Elastic documentation files for frontmatter completeness and correctness. Checks applies_to, products, description, and navigation_title fields across a directory. Use when auditing docs metadata, checking frontmatter quality before publishing, or validating a batch of files.
 argument-hint: <file-or-directory>
 context: fork
-allowed-tools: Read, Grep, Glob
+allowed-tools: Read, Grep, Glob, CallMcpTool, WebFetch
 sources:
+  - https://elastic.github.io/docs-builder/syntax/frontmatter/
   - https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/reference
   - https://developers.google.com/search/docs/appearance/snippet
 ---
@@ -32,7 +33,7 @@ You are a frontmatter auditor for Elastic documentation. Your job is to check al
 
 `$ARGUMENTS` is a file path or directory to audit. If empty, ask the user what to audit.
 
-Before starting, ask the user to confirm these configuration defaults or provide overrides:
+Use these configuration defaults unless the user provides overrides. Ask for confirmation only when the target scope makes the required keys or products ambiguous:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
@@ -49,7 +50,7 @@ Check each file for the following elements:
 Every page must have `applies_to` in its frontmatter. Verify:
 - Presence of all configured required keys
 - Valid lifecycle values: `preview`, `beta`, `ga`, `deprecated`, `removed`, `unavailable`
-- Valid version syntax if present (e.g., `ga 9.1`, `preview 9.0, ga 9.2`)
+- Valid version syntax if present (for example, `ga 9.1+`, `preview =9.0`, `beta 9.1-9.2`, `preview =9.0, ga 9.2+`)
 - No mixed dimensions (stack/serverless keys should not be combined with deployment keys)
 
 ```yaml
@@ -62,7 +63,7 @@ Flag files missing this element or missing required keys. Preserve existing vers
 
 ### 2. `products` (mandatory)
 
-Must include the configured required product IDs. May include additional products.
+Must include the configured required product IDs. May include additional products. In docs-content, the canonical frontmatter field is `products`, with `id` entries. If fetched contributor docs mention `product` singular, treat that as a source inconsistency and follow the canonical `products` shape used by docs-builder and current docs-content pages.
 
 ```yaml
 products:
@@ -70,6 +71,7 @@ products:
 ```
 
 Flag files missing this element or missing required products. Don't remove existing additional products.
+Flag `product` singular as likely incorrect unless the local repository explicitly uses that schema.
 
 ### 3. `description` (mandatory)
 
@@ -79,8 +81,8 @@ Validate against these rules:
 - Complete sentence (not a fragment or label)
 - No Jinja2 substitution variables (`{{kib}}`, `{{es}}`, `{{esql}}` — these aren't parsed in frontmatter)
 - No label prefixes ("Reference -", "Tutorial -", "Guide -")
-- Action-oriented (starts with a verb or content-type indicator)
-- No colons that could break YAML parsing
+- Clear, user-facing summary of the page content
+- Quoted if it contains punctuation or characters that could be misread by YAML, including colons
 
 ### 4. `navigation_title` (recommended)
 

--- a/skills/review/frontmatter-audit/evals/evals.json
+++ b/skills/review/frontmatter-audit/evals/evals.json
@@ -57,6 +57,28 @@
         "Flags the missing 'products' element",
         "Produces a structured report with these issues"
       ]
+    },
+    {
+      "id": 6,
+      "prompt": "Audit this file's frontmatter:\n\n---\napplies_to:\n  stack: ga\nproducts:\n  - id: elasticsearch\ndescription: Index lifecycle management automates index transitions through phases to optimize storage and performance.\n---\n\n# Index lifecycle management [index-lifecycle-management]",
+      "expected_output": "Report that the description is acceptable even though it does not start with an action verb, and does not flag product singular because the file uses canonical products frontmatter",
+      "expectations": [
+        "Does NOT require the description to start with an action verb",
+        "Recognizes products with id entries as the canonical docs-content shape",
+        "Does NOT suggest changing products to product singular",
+        "Only flags applies_to keys or products if they conflict with the configured audit requirements"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Audit this file's frontmatter:\n\n---\napplies_to:\n  stack: ga\nproduct: elasticsearch\ndescription: \"Troubleshoot shard allocation: identify common causes and resolve them.\"\n---\n\n# Troubleshoot shard allocation [troubleshoot-shard-allocation]",
+      "expected_output": "Report flagging product singular as likely incorrect for docs-content and accepting the quoted description with a colon",
+      "expectations": [
+        "Flags product singular as likely incorrect unless the local repo schema requires it",
+        "Accepts the description because the colon is safely quoted",
+        "Does NOT flag the description solely because it contains a colon",
+        "Produces a structured report"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Refresh docs style, frontmatter, applies_to, and content type skills against current Elastic documentation guidance.
- Tighten applies_to version syntax guidance, including explicit open-ended versions, exact versions, ranges, and deprecated ess handling in favor of ech.
- Add eval coverage for the updated style, frontmatter, applies_to, content type, and changelog review expectations.

## Test plan
- [x] Validate all updated eval JSON files with python3 -m json.tool.
- [x] Review the committed diff against origin/main.

Made with [Cursor](https://cursor.com)