### PR TITLE
Add `context: fork` to frontmatter-description and page-opening-optimizer

### DIFF
--- a/skills/authoring/frontmatter-description/SKILL.md
+++ b/skills/authoring/frontmatter-description/SKILL.md
@@ -3,6 +3,7 @@ name: docs-frontmatter-description
 version: 1.0.1
 description: Generate or improve meta descriptions in Elastic documentation frontmatter following SEO best practices. Use when adding description fields to doc pages, auditing missing descriptions, or improving metadata for search discoverability.
 argument-hint: <file-or-directory>
+context: fork
 allowed-tools: Read, Grep, Glob, Edit
 sources:
   - https://developers.google.com/search/docs/appearance/snippet

--- a/skills/authoring/page-opening-optimizer/SKILL.md
+++ b/skills/authoring/page-opening-optimizer/SKILL.md
@@ -3,6 +3,7 @@ name: docs-page-opening-optimizer
 version: 1.0.2
 description: Optimize the opening of an Elastic documentation page — H1 title, opening paragraph, and requirements section — following doc type conventions. Use when writing or improving page intros, optimizing titles for discoverability, adding requirements sections, or when the user asks to improve the first lines of a doc page.
 argument-hint: <file-or-directory>
+context: fork
 allowed-tools: Read, Grep, Glob, Edit, Shell
 sources:
   - https://www.elastic.co/docs/contribute-docs/content-types/overviews


### PR DESCRIPTION
## Summary

These two authoring skills are missing the `context: fork` field that the other skills in this repo declare in their SKILL.md frontmatter. Without it, the gh-aw runtime skips skill registration — the agent gets a `Skill not found` error when invoking either skill, even though the APM bundle deploys correctly.

## Evidence

5/5 correlation across recent runs in elastic/docs-content (sample: https://github.com/elastic/docs-content/actions/runs/25376415619):

| Skill | `context:` field | Outcome |
|---|---|---|
| `docs-frontmatter-audit` | `fork` | ✓ works |
| `docs-applies-to-tagging` | `fork` | ✓ works |
| `docs-check-style` | `fork` | ✓ works |
| `docs-frontmatter-description` | (missing) | ✗ "Skill not found" |
| `docs-page-opening-optimizer` | (missing) | ✗ "Skill not found" |

In each failing case, the agent's `skill(skill: docs-X)` call returns `Skill not found`. The APM step deployed the package fine; the agent runtime just refuses to register skills without the `context:` declaration.

## Fix

One line added to each SKILL.md frontmatter:

```diff
 argument-hint: <file-or-directory>
+context: fork
 allowed-tools: Read, Grep, Glob, ...
```

## Effect

After merge:

- The `docs-page-opening-optimizer` skill becomes invocable, unblocking [docs-content's docs-openings-sweep](https://github.com/elastic/docs-content/.github/workflows/docs-openings-sweep.yml). Currently noop'ing because the skill registration fails.
- The `docs-frontmatter-description` skill becomes invocable in the docs-frontmatter-sweep — improving the SEO description suggestions which currently fall back to the agent's own judgment.

No consumer-side changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)