### PR TITLE
Bump frontmatter-description (1.0.2) and page-opening-optimizer (1.0.3)

### DIFF
--- a/skills/authoring/frontmatter-description/SKILL.md
+++ b/skills/authoring/frontmatter-description/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-frontmatter-description
-version: 1.0.1
+version: 1.0.2
 description: Generate or improve meta descriptions in Elastic documentation frontmatter following SEO best practices. Use when adding description fields to doc pages, auditing missing descriptions, or improving metadata for search discoverability.
 argument-hint: <file-or-directory>
 context: fork

--- a/skills/authoring/page-opening-optimizer/SKILL.md
+++ b/skills/authoring/page-opening-optimizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-page-opening-optimizer
-version: 1.0.2
+version: 1.0.3
 description: Optimize the opening of an Elastic documentation page — H1 title, opening paragraph, and requirements section — following doc type conventions. Use when writing or improving page intros, optimizing titles for discoverability, adding requirements sections, or when the user asks to improve the first lines of a doc page.
 argument-hint: <file-or-directory>
 context: fork


### PR DESCRIPTION
## Summary

Companion to #63. That PR added `context: fork` to both skills' frontmatter — a behavioral change in how each skill registers with the gh-aw runtime. This PR bumps the version field accordingly so:

- Consumers can see the change in their dependency manifests.
- Any cache key downstream that includes the skill `version` is invalidated automatically.
- Future archaeologists looking at SKILL.md commit history have a clean before/after marker.

## Bumps

| Skill | Before | After |
|---|---|---|
| `docs-frontmatter-description` | 1.0.1 | 1.0.2 |
| `docs-page-opening-optimizer` | 1.0.2 | 1.0.3 |

No behavior change beyond what #63 already delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)