### PR TITLE
Improve fix-changelog and review-changelog skills

### DIFF
--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -97,7 +97,7 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 - **No buried lede:** If title is vague, fold in concrete detail from description so release notes stand alone
 - **Base-form verb requirement:** Use `Fix`, `Add`, `Remove` (not third-person `Fixes`, `Adds`, `Removes`)
 - **Sentence case:** Follow standard sentence capitalization
-- Feature prefixes in titles: `ESQL: Fix nullify` should be contextual like `Fix nullify in ES|QL`
+- **Feature/app prefix integration:** Detect `[Feature/App]: [Action]` patterns and suggest contextual alternatives (e.g., "File upload: Fix bug" → "Fix bug in file upload tool"). Target UI components, feature names, 1-4 word capitalized phrases. Skip technical terms (e.g., "Authorization: Bearer"), API references, code identifiers.
 
 **2. Technical term enhancement fixes:**
 
@@ -276,6 +276,18 @@ Also check for formatting anti-patterns in existing `description`, `impact`, and
 - **High confidence:** Repository configuration loaded successfully, using authoritative area validation
 - **Medium confidence:** Repository config partially available or unclear
 - **Low confidence:** No repository configuration found, using generic validation rules
+
+**Feature/app prefix integration patterns:**
+
+- `"[Feature]: Fix [issue]"` → `"Fix [issue] in [feature]"`
+- `"[Feature]: Enable [capability]"` → `"Enable [capability] for [feature]"`  
+- `"[Feature]: Add [functionality]"` → `"Add [functionality] to [feature]"`
+
+**Feature prefix suggestion confidence:**
+
+- **High confidence:** Clear UI component names, known Elastic features, good PR context
+- **Medium confidence:** Ambiguous feature names, partial context
+- **Low confidence:** Could be technical term vs feature name, missing PR details
 
 **Mode A & B** — for each weak or malformed field, show:
 

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -121,9 +121,8 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 
 **5. UI element formatting fixes:**
 
-- **Bold UI labels:** Button names, page titles, tabs, dropdown names, column names (e.g., **Save**, **Service Inventory**)
-- **Include articles:** Use "the **Overview** tab" not "**Overview** tab"  
-- **Capitalize feature names:** Don't bold feature names — capitalize them (Machine Learning, Elastic Security)
+- **Quote UI labels if unclear:** Button names, page titles, tabs, dropdown names, column names (e.g., "Service Inventory") 
+- **Capitalize feature names:** Don't quote feature names — capitalize them (Machine Learning, Elastic Security)
 - **Code identifiers:** Use backticks for field names, parameters, API endpoints (`index.refresh_interval`)
 - **When uncertain:** Note formatting uncertainty if UI label vs feature name is unclear
 

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -74,7 +74,12 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 1. If the user passed a second argument or quoted text in `$ARGUMENTS`, treat it as context
 2. If the conversation already contains PR or issue title, description, diff, or linked references, use that
 3. If `prs` or `issues` fields in the existing file (Mode A) contain URLs, use those as implicit context — they identify the PR or issue the changelog describes
-4. If none of the above is available, ask once: "Do you have context from a PR or issue (title, description, diff, or linked references) to share? Richer context produces better suggestions." Skip this ask if the user has already declined.
+4. If none of the above is available, ask once: "Do you have context from a PR or issue (title, description, diff, or linked references) to share? **If there are acronyms in the title (like 'KI'), please clarify what they stand for.** Richer context produces better suggestions." Skip this ask if the user has already declined.
+
+**Enhanced context utilization for acronyms:**
+
+- **Scan for acronym definitions:** In PR titles/descriptions, look for patterns like "KI (Knowledge Indicator)" or context clues that define abbreviations
+- **Cross-reference expansions:** Before expanding acronyms, check if PR context contradicts assumed meaning
 
 **Track for confidence:** Document what context was available (full PR details, partial info, URLs only, or none) and any fetch failures. This will inform confidence scoring in Step 7.
 
@@ -99,6 +104,8 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 - Add backticks around class/method names, config keys, API endpoints, or code identifiers where missing
 - Convert British spelling to US English: `serialise` → `serialize`, `colour` → `color`
 - Expand abbreviations where full form would be clearer: `params` → `parameters`
+- **Acronym expansion caution:** When expanding abbreviations/acronyms (2-4 uppercase letters), flag as uncertain unless clearly defined in PR context or covered in `docs-flag-jargon-skill` patterns
+- **Elastic acronym validation:** For common Elastic acronyms, cross-reference with patterns from `docs-flag-jargon-skill` if uncertain about expansion
 - Standardize format: `ESQL` → `ES|QL`
 
 **3. Content quality fixes:**
@@ -398,6 +405,7 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 
 ### Terminology uncertainties:
 - [Term/phrase]: Assumed [interpretation] — [Why uncertain, e.g., "Could be UI element vs feature name", "Missing domain context"]
+- [Acronym]: Expanded to "[expansion]" — [Confidence level: High/Medium/Low based on PR context, jargon-skill patterns, or domain knowledge]
 
 ### Assumptions made:
 - [Assumption]: [Rationale, e.g., "Normalized technical term based on common Elastic usage", "Inferred user impact from limited PR description"]

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: docs-fix-changelog
-version: 1.0.2
-description: Suggest improved text for weak or missing fields in Elastic changelog YAML files. Accepts optional PR or issue context (title, description, diff, linked issues) to produce better suggestions. Use after docs-review-changelog identifies quality issues, or when drafting a new changelog from a PR or issue.
-argument-hint: "[changelog-file] [pr/issue-context]"
+version: 2.0.0
+description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
+argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
 context: fork
-allowed-tools: Read, Grep, Glob
+allowed-tools: Read, Grep, Glob, WebFetch
 sources:
   - https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs
   - https://www.elastic.co/docs/contribute-docs/content-types/changelogs
@@ -30,20 +30,49 @@ under the License. -->
 
 You are a changelog writing assistant for Elastic documentation. You suggest improved text for changelog fields and help draft content for new changelogs. You do not create files — file creation is always done via `docs-builder changelog add`.
 
+## How to use this skill
+
+This skill pairs with `docs-review-changelog` as part of a systematic changelog improvement workflow:
+
+1. **Review first:** Use `docs-review-changelog` to identify schema errors, quality warnings, and systematic pattern violations
+2. **Fix second:** Use this skill to get specific improvement suggestions that address the same pattern catalog
+3. **Optional iteration:** Run both tools again before merge for final validation
+
+**Common workflows:**
+
+- **Single file:** `/docs-fix-changelog path/to/changelog.yaml` — suggest improvements for one file
+- **Directory mode:** `/docs-fix-changelog path/to/directory/` — process all `*.yaml` and `*.yml` files in the directory
+- **New changelog:** `/docs-fix-changelog "Create new changelog for: [PR context]"` — suggest content for a new changelog
+
+**Default behavior:** Suggest-only mode. Changes are only applied to disk after explicit user confirmation.
+
+## Step 1: Load canonical guidance (recommended)
+
+To ensure fix suggestions align with the latest Elastic changelog standards, attempt to fetch current guidance:
+
+1. **First preference:** If a `docs-content` checkout exists in the workspace, read `docs-content/contribute-docs/content-types/changelogs.md`
+2. **Second preference:** Fetch the published guide at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>
+3. **Fallback:** Use the embedded post-edit checklist in this skill (Steps 3-4) if the above sources are unavailable
+
+**Purpose:** This ensures fix suggestions match the most current writer guidance. If successful, cross-check key patterns (title cleanup checklist, technical terms guidance, anti-patterns) against what's embedded in this skill. If there are significant discrepancies, note this in the final output.
+
 ## Operating modes
 
 **Mode A — Improve an existing file.** The first argument is a path to a changelog YAML file that already exists. Read it, assess weak or missing fields, and suggest improvements.
 
-**Mode B — Suggest content for a new file.** No file path is given (or the argument doesn't resolve to a readable file). Suggest text for the text-based fields that the user can pass to `docs-builder changelog add`.
+**Mode B — Process directory.** The first argument is a path to a directory containing changelog files. Process all `*.yaml` and `*.yml` files in that directory, suggesting improvements for each.
 
-Detect mode automatically: if the first argument resolves to a readable file, use Mode A. Otherwise, use Mode B.
+**Mode C — Suggest content for a new file.** No file path is given, or the argument doesn't resolve to a readable file or directory. Suggest text for the text-based fields that the user can pass to `docs-builder changelog add`.
 
-## Step 1: Determine mode and read input
+Detect mode automatically: if the first argument resolves to a readable file, use Mode A. If it resolves to a directory, use Mode B. Otherwise, use Mode C.
+
+## Step 2: Determine mode and read input
 
 - **Mode A**: Read and parse the changelog file. If YAML parsing fails, report the error and stop.
-- **Mode B**: No file to read. Proceed to Step 2.
+- **Mode B**: Glob for `*.yaml` and `*.yml` files in the directory. Parse each file as YAML. If parsing fails for any file, report the error for that file but continue processing others.
+- **Mode C**: No file to read. Proceed to Step 3.
 
-## Step 2: Resolve PR/issue context
+## Step 3: Resolve PR/issue context
 
 Context from a PR or issue produces better suggestions. Use it in this order:
 
@@ -52,9 +81,48 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 3. If `prs` or `issues` fields in the existing file (Mode A) contain URLs, use those as implicit context — they identify the PR or issue the changelog describes
 4. If none of the above is available, ask once: "Do you have context from a PR or issue (title, description, diff, or linked references) to share? Richer context produces better suggestions." Skip this ask if the user has already declined.
 
-## Step 3: Assess fields
+## Step 4: Apply post-edit checklist
 
-**Mode A** — identify fields that need improvement:
+**Before field-level assessment**, apply the systematic pattern checklist that mirrors the warnings from `docs-review-changelog`. This ensures consistent improvement patterns across both tools.
+
+**Systematic pattern fixes (apply to all text fields where relevant):**
+
+**1. Title standardization fixes (from canonical Title cleanup checklist):**
+
+- **Strip development labels:** Remove prefixes such as `feat:`, `fix:`, `Fix:`, `auto-implement:`, and trailing tracker fragments like `Bugfix -`
+- **No bracket-only team tags:** Replace `[Security Solution]`, `[Query Rules]`, `[Inference]`, and similar with plain, user-facing wording
+- **Strong verbs:** Prefer *Improve validation for...* over *Better validation for...* (use present tense imperative: Fix, Add, Remove)
+- **No buried lede:** If title is vague, fold in concrete detail from description so release notes stand alone
+- **Base-form verb requirement:** Use `Fix`, `Add`, `Remove` (not third-person `Fixes`, `Adds`, `Removes`)
+- **Sentence case:** Follow standard sentence capitalization
+
+**2. ES|QL contextual integration fixes:**
+
+- Avoid naked ES|QL or ESQL prefixes in titles: `ESQL: Fix nullify` should be contextual like `Fix nullify in ES|QL`
+- Standardize format: `ESQL` → `ES|QL`
+- When `areas` field already specifies "ES|QL", avoid redundant ES|QL in title
+
+**3. Technical term enhancement fixes:**
+
+- Add backticks around class/method names, config keys, API endpoints, or code identifiers where missing
+- Convert British spelling to US English: `serialise` → `serialize`, `colour` → `color`
+- Expand abbreviations where full form would be clearer: `params` → `parameters`
+
+**4. Content quality fixes:**
+
+- Make vague titles more specific based on description content
+- Remove redundant descriptions that just repeat the title without adding context
+- Replace `UX` terminology with `UI` for interface changes
+- Focus on user-visible outcomes instead of implementation details
+
+**5. YAML formatting fixes:**
+
+- Quote text containing special characters (backticks, colons, brackets) to prevent parse errors
+- Ensure consistent formatting across text fields
+
+## Step 5: Assess fields
+
+**Mode A & B** — identify fields that need improvement (apply to each file processed):
 
 - `title`: too vague, implementation-focused, wrong tense, missing action verb, or over 80 characters
 - `description`: absent but would add value, or present but low quality (repeats title, says "See PR", says "Internal refactoring")
@@ -63,25 +131,28 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 - `feature-id` if present: must be a string; no content quality check needed, just YAML type correctness
 
 Also check for formatting anti-patterns in existing `description`, `impact`, and `action` values:
+
 - Bare URLs used as link text
 - Code fences missing a language identifier
 - Field names, config keys, commands, or API endpoints written as plain text instead of inline code
-- Unquoted values containing `: ` (colon + space), `#`, `[`, `]`, `{`, or `}` — these cause YAML parse errors
+- Unquoted values containing `:` (colon + space), `#`, `[`, `]`, `{`, or `}` — these cause YAML parse errors
 
-**Mode B** — determine which fields to suggest based on `type` (ask if unknown):
+**Mode C** — determine which fields to suggest based on `type` (ask if unknown):
+
 - All types: `title` (required), `description` (recommended)
 - `breaking-change`, `deprecation`, `known-issue`: also `impact` and `action`
 
-## Step 4: Generate suggestions
+## Step 6: Generate suggestions
 
 **Character limits:** Title max 80 characters. Description max 600 characters. If a suggestion is too long, shorten it or split across title and description.
 
-**Mode A** — for each weak or malformed field, show:
+**Mode A & B** — for each weak or malformed field, show:
+
 - Current value (or "not present")
 - One or two suggested alternatives
 - Brief explanation of what makes the suggestion better
 
-**Mode B** — suggest text for each relevant field, then present a ready-to-copy `docs-builder changelog add` command:
+**Mode C** — suggest text for each relevant field, then present a ready-to-copy `docs-builder changelog add` command:
 
 ```sh
 docs-builder changelog add \
@@ -101,7 +172,7 @@ Remind the user that `--products`, `--prs`, `--issues`, and other non-text optio
 - **`breaking-change`**: `impact` must explain what breaks and who is affected; `action` must give ordered, prescriptive migration steps — include code examples if context allows; `subtype` is strongly recommended
 - **`deprecation`**: `action` should name the replacement and link to migration guidance
 - **`feature`** / **`enhancement`**: title and description should answer "what can I now do?" not "what did we build?"
-- **`bug-fix`** / **`regression`**: title should follow "Fixes [symptom] in [context]"
+- **`bug-fix`** / **`regression`**: title should follow "Fix [symptom] in [context]" (base-form verb)
 - **`known-issue`**: include all affected versions and contexts; describe any available workaround in `action`
 
 ## Formatting rules for suggested text
@@ -110,7 +181,7 @@ All suggested `title`, `description`, `impact`, and `action` content must follow
 
 ### YAML quoting
 
-Always wrap text field values in double quotes in any YAML output. This is mandatory when the value contains `: ` (colon + space), `#`, `[`, `]`, `{`, or `}` — these characters cause YAML parse errors in unquoted scalars. Escape any double-quote characters within the value with a backslash (`\"`).
+Always wrap text field values in double quotes in any YAML output. This is mandatory when the value contains `:` (colon + space), `#`, `[`, `]`, `{`, or `}` — these characters cause YAML parse errors in unquoted scalars. Escape any double-quote characters within the value with a backslash (`\"`).
 
 Good: `description: "Removes the --path.home flag: it had no effect"`
 Bad: `description: Removes the --path.home flag: it had no effect`
@@ -134,8 +205,14 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 - Add `subs=true` when the block contains docs-builder substitution variables
 - Add callouts (`<1>`, `<2>`) only when annotation adds real value; always follow with a matching ordered list
 
-## Step 5: Present output
+## Step 7: Present output
 
 **Mode A:** Present "current → suggested" pairs for each field. Do not apply changes without user confirmation.
 
-**Mode B:** Present the suggested field text, followed by the ready-to-copy `docs-builder changelog add` command. Invite the user to confirm or adjust before running the command. Make clear that the skill does not create the file — `changelog add` does.
+**Mode B:** Present results for each file processed in the directory. For files needing improvements, show "current → suggested" pairs. Summarize at the end with a count of files processed and files needing improvements. Do not apply changes without user confirmation.
+
+**Mode C:** Present the suggested field text, followed by the ready-to-copy `docs-builder changelog add` command. Invite the user to confirm or adjust before running the command. Make clear that the skill does not create the file — `changelog add` does.
+
+**All modes:** Default behavior is suggest-only. Only apply changes to disk after explicit user confirmation. After writing changes, re-parse YAML to validate the result.
+
+**Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your output. Note which patterns may need updating and suggest checking the canonical source directly at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,32 +1,18 @@
 ---
-name: docs-fix-changelog
-version: 2.1.0
-description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes confidence scoring and assumption tracking for suggestion transparency. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
-argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
-context: fork
-allowed-tools: Read, Grep, Glob, WebFetch
-sources:
-  - https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs
-  - https://www.elastic.co/docs/contribute-docs/content-types/changelogs
-  - https://elastic.github.io/docs-builder/syntax/links/
-  - https://elastic.github.io/docs-builder/syntax/code/
----
-<!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-or more contributor license agreements. See the NOTICE file distributed with
-this work for additional information regarding copyright
-ownership. Elasticsearch B.V. licenses this file to you under
-the Apache License, Version 2.0 (the "License"); you may
-not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+## name: docs-fix-changelog  
+version: 2.0.0  
+description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes confidence scoring and assumption tracking for suggestion transparency. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.  
+argument-hint: "[changelog-file-or-directory] [pr/issue-context]"  
+context: fork  
+allowed-tools: Read, Grep, Glob, WebFetch  
+sources:  
+  - [https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs)
+  - [https://www.elastic.co/docs/contribute-docs/content-types/changelogs](https://www.elastic.co/docs/contribute-docs/content-types/changelogs)
+  - [https://elastic.github.io/docs-builder/syntax/links/](https://elastic.github.io/docs-builder/syntax/links/)
+  - [https://elastic.github.io/docs-builder/syntax/code/](https://elastic.github.io/docs-builder/syntax/code/)
 
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License. -->
+
 
 You are a changelog writing assistant for Elastic documentation. You suggest improved text for changelog fields and help draft content for new changelogs. You do not create files — file creation is always done via `docs-builder changelog add`.
 
@@ -51,7 +37,7 @@ This skill pairs with `docs-review-changelog` as part of a systematic changelog 
 To ensure fix suggestions align with the latest Elastic changelog standards, attempt to fetch current guidance:
 
 1. **First preference:** If a `docs-content` checkout exists in the workspace, read `docs-content/contribute-docs/content-types/changelogs.md`
-2. **Second preference:** Fetch the published guide at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>
+2. **Second preference:** Fetch the published guide at [https://www.elastic.co/docs/contribute-docs/content-types/changelogs](https://www.elastic.co/docs/contribute-docs/content-types/changelogs)
 3. **Fallback:** Use the embedded post-edit checklist in this skill (Steps 3-4) if the above sources are unavailable
 
 **Purpose:** This ensures fix suggestions match the most current writer guidance. If successful, cross-check key patterns (title cleanup checklist, technical terms guidance, anti-patterns) against what's embedded in this skill. If there are significant discrepancies, note this in the final output.
@@ -168,17 +154,17 @@ docs-builder changelog add \
   --action "<suggested action>"
 ```
 
-Omit `--impact` and `--action` when not applicable to the type. Note that inside shell-quoted values, backticks must be escaped with a backslash (`` \` ``) and double quotes must be escaped (`\"`).
+Omit `--impact` and `--action` when not applicable to the type. Note that inside shell-quoted values, backticks must be escaped with a backslash (`\``) and double quotes must be escaped (`\"`).
 
 Remind the user that `--products`, `--prs`, `--issues`, and other non-text options must be provided separately. Refer them to `docs-builder changelog add --help` for the full list.
 
 ### Type-specific guidance
 
-- **`breaking-change`**: `impact` must explain what breaks and who is affected; `action` must give ordered, prescriptive migration steps — include code examples if context allows; `subtype` is strongly recommended
-- **`deprecation`**: `action` should name the replacement and link to migration guidance
-- **`feature`** / **`enhancement`**: title and description should answer "what can I now do?" not "what did we build?"
-- **`bug-fix`** / **`regression`**: title should follow "Fix [symptom] in [context]" (base-form verb)
-- **`known-issue`**: include all affected versions and contexts; describe any available workaround in `action`
+- `**breaking-change**`: `impact` must explain what breaks and who is affected; `action` must give ordered, prescriptive migration steps — include code examples if context allows; `subtype` is strongly recommended
+- `**deprecation**`: `action` should name the replacement and link to migration guidance
+- `**feature**` / `**enhancement**`: title and description should answer "what can I now do?" not "what did we build?"
+- `**bug-fix**` / `**regression**`: title should follow "Fix [symptom] in [context]" (base-form verb)
+- `**known-issue**`: include all affected versions and contexts; describe any available workaround in `action`
 
 ## Formatting rules for suggested text
 
@@ -201,11 +187,11 @@ Bad: `description: Removes the --path.home flag: it had no effect`
 
 ### Inline code
 
-Use backticks for field names, parameter names, config keys, API endpoints, commands, and specific values — e.g. `` `index.refresh_interval` ``, `` `POST /_reindex` ``.
+Use backticks for field names, parameter names, config keys, API endpoints, commands, and specific values — e.g. ``index.refresh_interval``, ``POST /_reindex``.
 
 ### Code blocks
 
-- Always include a language identifier: ` ```yaml `, ` ```json `, ` ```bash `, ` ```console `
+- Always include a language identifier: ````yaml`, ````json`, ````bash`, ````console`
 - Use `console` for Elasticsearch API requests — it renders with a Kibana Dev Console link
 - Add `subs=true` when the block contains docs-builder substitution variables
 - Add callouts (`<1>`, `<2>`) only when annotation adds real value; always follow with a matching ordered list
@@ -250,4 +236,4 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 
 **Default behavior:** Default behavior is suggest-only. Only apply changes to disk after explicit user confirmation. After writing changes, re-parse YAML to validate the result.
 
-**Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your output. Note which patterns may need updating and suggest checking the canonical source directly at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.
+**Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your output. Note which patterns may need updating and suggest checking the canonical source directly at [https://www.elastic.co/docs/contribute-docs/content-types/changelogs](https://www.elastic.co/docs/contribute-docs/content-types/changelogs).

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -15,6 +15,8 @@ sources:
 
 You are a changelog writing assistant for Elastic documentation. You suggest improved text for changelog fields and help draft content for new changelogs. You do not create files — file creation is always done via `docs-builder changelog add`.
 
+**Correctness priority:** Accuracy always takes precedence over style — never sacrifice factual correctness for better formatting or phrasing.
+
 ## How to use this skill
 
 This skill pairs with `docs-review-changelog` as part of a systematic changelog improvement workflow:
@@ -109,6 +111,14 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 
 - Quote text containing special characters (backticks, colons, brackets) to prevent parse errors
 - Ensure consistent formatting across text fields
+
+**5. UI element formatting fixes:**
+
+- **Bold UI labels:** Button names, page titles, tabs, dropdown names, column names (e.g., **Save**, **Service Inventory**)
+- **Include articles:** Use "the **Overview** tab" not "**Overview** tab"  
+- **Capitalize feature names:** Don't bold feature names — capitalize them (Machine Learning, Elastic Security)
+- **Code identifiers:** Use backticks for field names, parameters, API endpoints (`index.refresh_interval`)
+- **When uncertain:** Note formatting uncertainty if UI label vs feature name is unclear
 
 ## Step 4.5: Type-Title Alignment Check
 
@@ -405,6 +415,12 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 - **Low confidence triggers:** Missing PR context, ambiguous technical terms, conflicting pattern interpretations, failed resource fetches, domain-specific terminology without clear context
 - **Medium confidence:** Partial PR context, standard technical terms, routine pattern fixes with good guidance
 - **High confidence:** Full context available, canonical guidance loaded, routine formatting/structural fixes
+
+**Enhanced confidence methodology:**
+
+- **Document all uncertainties:** Explicitly flag each suggestion where multiple interpretations are possible
+- **Track assumption rationales:** Always explain why you chose one interpretation over another
+- **Resource dependency transparency:** Clearly indicate which suggestions depend on successfully loaded canonical guidance vs fallback patterns
 
 **Default behavior:** Default behavior is suggest-only. Only apply changes to disk after explicit user confirmation. After writing changes, re-parse YAML to validate the result.
 

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,16 +1,15 @@
 ---
-
-## name: docs-fix-changelog  
-version: 2.0.0  
-description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes confidence scoring and assumption tracking for suggestion transparency. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.  
-argument-hint: "[changelog-file-or-directory] [pr/issue-context]"  
-context: fork  
-allowed-tools: Read, Grep, Glob, WebFetch  
-sources:  
-  - [https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs)
-  - [https://www.elastic.co/docs/contribute-docs/content-types/changelogs](https://www.elastic.co/docs/contribute-docs/content-types/changelogs)
-  - [https://elastic.github.io/docs-builder/syntax/links/](https://elastic.github.io/docs-builder/syntax/links/)
-  - [https://elastic.github.io/docs-builder/syntax/code/](https://elastic.github.io/docs-builder/syntax/code/)
+name: docs-fix-changelog
+version: 2.0.0
+description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes type-title alignment checking to catch systematic misclassifications. Features confidence scoring and assumption tracking for suggestion transparency. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
+argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
+context: fork
+allowed-tools: Read, Grep, Glob, WebFetch
+sources:
+- https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs
+- https://www.elastic.co/docs/contribute-docs/content-types/changelogs
+- https://elastic.github.io/docs-builder/syntax/links/
+- https://elastic.github.io/docs-builder/syntax/code/
 
 
 
@@ -105,6 +104,54 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 - Quote text containing special characters (backticks, colons, brackets) to prevent parse errors
 - Ensure consistent formatting across text fields
 
+## Step 4.5: Type-Title Alignment Check
+
+**Before generating suggestions**, validate that `type` and `title` verb patterns align. This catches systematic misclassifications where the content doesn't match the declared type.
+
+### Type-Verb Alignment Rules
+
+**`bug-fix` / `regression`:**
+
+- **Expected verbs:** `Fix`, `Resolve`, `Correct`
+- **Expected pattern:** "Fix [symptom] in [context]"
+- **Flag if title uses:** `Improve`, `Enable`, `Update`, `Enhance`
+- **Action:** Suggest either changing type to `enhancement` OR rewriting title to describe what was broken
+
+**`enhancement`:**
+
+- **Expected verbs:** `Improve`, `Update`, `Optimize`, `Enable`, `Expand`, `Enhance`
+- **Expected pattern:** "Improve [capability] for [context]"  
+- **Flag if title uses:** `Fix`, `Resolve`, `Correct`
+- **Action:** Suggest either changing type to `bug-fix` OR rewriting title to focus on improvement/capability
+
+**`feature`:**
+
+- **Expected verbs:** `Add`, `Introduce`, `Enable`, `Support`  
+- **Expected pattern:** "Add [new capability] for [users]"
+- **Flag if title uses:** `Fix`, `Improve` (unless truly new)
+- **Action:** Major new functionality → `feature`. Minor additions → `enhancement`
+
+**`docs`:**
+
+- **Expected verbs:** `Update`, `Add`, `Clarify`, `Document`
+- **Expected pattern:** "Update [documentation] for [clarity/accuracy]"
+
+**`breaking-change` / `deprecation` / `known-issue` / `security`:**
+
+- **Any appropriate verb** but should align with the actual change nature
+- **Focus on clarity** rather than strict verb patterns
+
+### Alignment Assessment Process
+
+For each changelog:
+
+1. **Extract leading verb** from title (first word after articles/prepositions)
+2. **Check against expected verbs** for the declared type
+3. **If mismatch detected**, provide both options:
+   - **Option A:** Keep type, rewrite title with appropriate verb
+   - **Option B:** Keep title, suggest more appropriate type
+4. **Include confidence note** explaining which option is more likely correct based on PR context
+
 ## Step 5: Assess fields
 
 **Mode A & B** — identify fields that need improvement (apply to each file processed):
@@ -137,6 +184,21 @@ Also check for formatting anti-patterns in existing `description`, `impact`, and
 - **Medium confidence:** Technical terms with contextual clues, partial PR context, common Elastic terminology
 - **Low confidence:** Domain-specific terms without context, missing PR details, ambiguous phrasing that could have multiple interpretations, novel or uncommon technical concepts
 
+**Type-Title Alignment Confidence:**
+
+- **High confidence type corrections:**
+  - Clear functional behavior (Fix broken → `bug-fix`)
+  - Clear new capability (Add substantial → `feature`)  
+  - PR context confirms the classification
+
+- **Medium confidence:**
+  - Performance improvements (could be `enhancement` or `bug-fix` depending on whether previous performance was "broken")
+  - Minor additions (could be `enhancement` or `feature` depending on scope)
+
+- **Low confidence - provide both options:**
+  - Ambiguous PR context about whether behavior was broken or just suboptimal
+  - Edge cases between types (e.g., "fixing" by adding a missing capability)
+
 **Mode A & B** — for each weak or malformed field, show:
 
 - Current value (or "not present")
@@ -158,13 +220,50 @@ Omit `--impact` and `--action` when not applicable to the type. Note that inside
 
 Remind the user that `--products`, `--prs`, `--issues`, and other non-text options must be provided separately. Refer them to `docs-builder changelog add --help` for the full list.
 
-### Type-specific guidance
+### Enhanced Type-specific guidance
 
-- `**breaking-change**`: `impact` must explain what breaks and who is affected; `action` must give ordered, prescriptive migration steps — include code examples if context allows; `subtype` is strongly recommended
-- `**deprecation**`: `action` should name the replacement and link to migration guidance
-- `**feature**` / `**enhancement**`: title and description should answer "what can I now do?" not "what did we build?"
-- `**bug-fix**` / `**regression**`: title should follow "Fix [symptom] in [context]" (base-form verb)
-- `**known-issue**`: include all affected versions and contexts; describe any available workaround in `action`
+**`bug-fix` / `regression`:**
+
+- **Title pattern:** "Fix [symptom] in [context]" (base-form verb)
+- **Common misalignment:** Titles that say "Improve" when fixing broken behavior
+- **Resolution:** If behavior was broken → keep `bug-fix`, rewrite title. If adding new capability → change to `enhancement`
+- **Description should explain:** What was wrong, what's now correct
+- **Required fields:** `impact` and `action` recommended for regressions
+
+**`enhancement`:**  
+
+- **Title pattern:** "Improve [existing capability]" or "Add [minor capability]"
+- **Common misalignment:** Titles that say "Fix" for performance improvements
+- **Resolution:** If fixing objectively broken behavior → change to `bug-fix`. If optimizing working functionality → keep `enhancement`, rewrite title
+- **Description should explain:** What users can now do better/faster
+
+**`feature`:**
+
+- **Title pattern:** "Add [substantial new capability]"  
+- **Common misalignment:** Minor improvements labeled as features
+- **Resolution:** Major new functionality → `feature`. Minor additions → `enhancement`
+- **Description should explain:** What users can now do that they couldn't before
+
+**`breaking-change`:**
+
+- **Title pattern:** Any clear verb, but focus on impact clarity
+- **Required fields:** `impact` must explain what breaks and who is affected; `action` must give ordered, prescriptive migration steps — include code examples if context allows; `subtype` is strongly recommended
+
+**`deprecation`:**
+
+- **Title pattern:** "Deprecate [functionality]" or "Remove [functionality]" 
+- **Required fields:** `action` should name the replacement and link to migration guidance
+- **Optional fields:** `impact` recommended for high-impact deprecations
+
+**`known-issue`:**
+
+- **Title pattern:** Describe the issue clearly, not the investigation
+- **Required fields:** Include all affected versions and contexts; describe any available workaround in `action`
+
+**`docs`:**
+
+- **Title pattern:** "Update [documentation] for [clarity/accuracy]"
+- **Focus:** Content gaps addressed or user experience improvements
 
 ## Formatting rules for suggested text
 
@@ -214,6 +313,12 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 ### Least confident suggestions:
 - [Field]: [Specific suggestion] — [Reason for uncertainty, e.g., "Limited PR context", "Ambiguous technical term", "Multiple interpretation options"]
 
+### Type-title alignment issues:
+- [File]: Type `[current-type]` + Title "[current-title]" — [Mismatch description]
+  - **Option A:** Keep type, suggested title: "[new-title]"
+  - **Option B:** Keep title, suggested type: `[new-type]`
+  - **Recommendation:** [Which option with reasoning]
+
 ### Terminology uncertainties:
 - [Term/phrase]: Assumed [interpretation] — [Why uncertain, e.g., "Could be UI element vs feature name", "Missing domain context"]
 
@@ -236,4 +341,4 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 
 **Default behavior:** Default behavior is suggest-only. Only apply changes to disk after explicit user confirmation. After writing changes, re-parse YAML to validate the result.
 
-**Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your output. Note which patterns may need updating and suggest checking the canonical source directly at [https://www.elastic.co/docs/contribute-docs/content-types/changelogs](https://www.elastic.co/docs/contribute-docs/content-types/changelogs).
+**Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your output. Note which patterns may need updating and suggest checking the canonical source directly at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-fix-changelog
-version: 2.3.0
+version: 2.3.1
 description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes type-title alignment checking and technical content assessment to catch overly technical titles that need user-focused rewrites. Features repository-aware area validation and enhanced confidence scoring. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
 argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
 context: fork
@@ -212,7 +212,7 @@ For each changelog:
 **Mode A & B** — identify fields that need improvement (apply to each file processed):
 
 - `title`: too vague, implementation-focused, wrong tense, missing action verb, or over 80 characters
-- `description`: absent but would add value, or present but low quality (repeats title, says "See PR", says "Internal refactoring")
+- `description`: only suggest when title is vague; do not suggest when title is self-explanatory; flag present low-quality content (repeats title, "See PR", "Internal refactoring")
 - `impact` / `action`: absent on `breaking-change`, `deprecation`, or `known-issue`
 - `areas` if present: must be an array of strings; validate against repository configuration from Step 1 if available (only flag areas not in `docs/changelog.yml` pivot.areas section), otherwise use generic validation
 - `feature-id` if present: must be a string; no content quality check needed, just YAML type correctness
@@ -231,7 +231,7 @@ Also check for formatting anti-patterns in existing `description`, `impact`, and
 
 ## Step 6: Generate suggestions
 
-**Character limits:** Title max 80 characters. Description max 600 characters. If a suggestion is too long, shorten it or split across title and description.
+**Character limits:** Target 80/600 characters; prefer clarity over trimming; split excess detail into `description` rather than shortening accurate titles.
 
 **Confidence tracking:** During suggestion generation, note factors that affect confidence:
 

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docs-fix-changelog
-version: 2.0.0
-description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes type-title alignment checking to catch systematic misclassifications. Features confidence scoring and assumption tracking for suggestion transparency. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
+version: 2.3.0
+description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes type-title alignment checking and technical content assessment to catch overly technical titles that need user-focused rewrites. Features repository-aware area validation and enhanced confidence scoring. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
 argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
 context: fork
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -31,17 +31,23 @@ This skill pairs with `docs-review-changelog` as part of a systematic changelog 
 
 **Default behavior:** Suggest-only mode. Changes are only applied to disk after explicit user confirmation.
 
-## Step 1: Load canonical guidance (recommended)
+## Step 1: Load canonical guidance and repository configuration
 
-To ensure fix suggestions align with the latest Elastic changelog standards, attempt to fetch current guidance:
+To ensure fix suggestions align with current standards and repository-specific rules:
 
+### Canonical Guidance Loading
 1. **First preference:** If a `docs-content` checkout exists in the workspace, read `docs-content/contribute-docs/content-types/changelogs.md`
 2. **Second preference:** Fetch the published guide at [https://www.elastic.co/docs/contribute-docs/content-types/changelogs](https://www.elastic.co/docs/contribute-docs/content-types/changelogs)
-3. **Fallback:** Use the embedded post-edit checklist in this skill (Steps 3-4) if the above sources are unavailable
+3. **Fallback:** Use the embedded post-edit checklist in this skill if the above sources are unavailable
 
-**Purpose:** This ensures fix suggestions match the most current writer guidance. If successful, cross-check key patterns (title cleanup checklist, technical terms guidance, anti-patterns) against what's embedded in this skill. If there are significant discrepancies, note this in the final output.
+### Repository Configuration Loading
+1. **Area validation:** Look for `docs/changelog.yml` in the workspace to extract valid area values from the `pivot.areas` section
+2. **Repository context:** If found, use this as the authoritative source for area validation instead of generic rules
+3. **Fallback:** If no repository config found, note this limitation in confidence tracking
 
-**Track for confidence:** Document whether canonical guidance was successfully fetched and which source was used. Failed fetches or fallback to embedded patterns should be noted as factors affecting suggestion confidence.
+**Purpose:** This ensures fix suggestions match both current writer guidance and repository-specific validation rules. 
+
+**Track for confidence:** Document whether canonical guidance and repository config were successfully loaded. Failed fetches or fallbacks affect suggestion confidence and should be noted in the final output.
 
 ## Operating modes
 
@@ -152,6 +158,39 @@ For each changelog:
    - **Option B:** Keep title, suggest more appropriate type
 4. **Include confidence note** explaining which option is more likely correct based on PR context
 
+## Step 4.6: Technical Content Assessment
+
+**Before field-level assessment**, evaluate titles for overly technical language that focuses on implementation rather than user impact.
+
+### Technical Jargon Detection
+
+**Flag titles that prioritize implementation over user symptoms:**
+
+- **Class/method references without context**: "constructing ColorSeries", "splitValue nullability", "when building QueryNode"
+- **Internal process descriptions**: "coercion logic", "serialization handling", "initialization sequence"  
+- **Implementation-focused terminology**: Technical terms that don't explain what users experience
+- **Missing user-visible symptoms**: Titles describing code changes without explaining user impact
+
+### User Impact Assessment
+
+**Recognize titles that already focus on user experience:**
+- Clear symptom descriptions: "Fix inline charts with grey time series"
+- User-facing feature names: "ES|QL queries", "dashboard widgets", "alert notifications"
+- Observable behaviors: "slow loading", "incorrect results", "missing data"
+
+### Technical Content Scoring
+
+**High priority for user-focused rewrite:**
+- Title contains multiple technical terms without user context
+- Implementation details dominate over user symptoms  
+- Class names, method names, or internal concepts without explanation
+- Example: "Fix splitValue nullability coercion when constructing ColorSeries" → Should suggest user-focused alternative
+
+**Low priority for rewrite (formatting only):**
+- Title already describes user-visible symptoms clearly
+- Technical terms support rather than obscure user understanding
+- Example: "Fix inline charts with grey time series for ES|QL queries" → Minor formatting only
+
 ## Step 5: Assess fields
 
 **Mode A & B** — identify fields that need improvement (apply to each file processed):
@@ -159,7 +198,7 @@ For each changelog:
 - `title`: too vague, implementation-focused, wrong tense, missing action verb, or over 80 characters
 - `description`: absent but would add value, or present but low quality (repeats title, says "See PR", says "Internal refactoring")
 - `impact` / `action`: absent on `breaking-change`, `deprecation`, or `known-issue`
-- `areas` if present: must be an array of strings; flag if it contains values that don't look like valid product area names
+- `areas` if present: must be an array of strings; validate against repository configuration from Step 1 if available (only flag areas not in `docs/changelog.yml` pivot.areas section), otherwise use generic validation
 - `feature-id` if present: must be a string; no content quality check needed, just YAML type correctness
 
 Also check for formatting anti-patterns in existing `description`, `impact`, and `action` values:
@@ -198,6 +237,28 @@ Also check for formatting anti-patterns in existing `description`, `impact`, and
 - **Low confidence - provide both options:**
   - Ambiguous PR context about whether behavior was broken or just suboptimal
   - Edge cases between types (e.g., "fixing" by adding a missing capability)
+
+**Technical Content Assessment Confidence:**
+
+- **High confidence user-impact rewrites:**
+  - Titles heavy in class names, method names, or implementation details without user context
+  - Multiple technical terms that don't explain user symptoms
+  - Clear implementation focus over user experience (e.g., "Fix splitValue nullability coercion when constructing ColorSeries")
+
+- **Medium confidence:**
+  - Technical terms mixed with some user-facing language
+  - Partial user context but still implementation-heavy
+
+- **Low priority formatting-only suggestions:**
+  - Titles already focused on user symptoms and impact
+  - Technical terms support rather than obscure user understanding
+  - Clear user-facing language with minimal technical jargon
+
+**Repository Validation Confidence:**
+
+- **High confidence:** Repository configuration loaded successfully, using authoritative area validation
+- **Medium confidence:** Repository config partially available or unclear
+- **Low confidence:** No repository configuration found, using generic validation rules
 
 **Mode A & B** — for each weak or malformed field, show:
 
@@ -318,6 +379,12 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
   - **Option A:** Keep type, suggested title: "[new-title]"
   - **Option B:** Keep title, suggested type: `[new-type]`
   - **Recommendation:** [Which option with reasoning]
+
+### Technical content assessment:
+- [File]: Title "[current-title]" — [Technical assessment]
+  - **Issue:** [Implementation-focused vs user-focused description]
+  - **Suggested user-focused rewrite:** "[user-impact-focused title]"
+  - **Reasoning:** [Why the rewrite better serves users]
 
 ### Terminology uncertainties:
 - [Term/phrase]: Assumed [interpretation] — [Why uncertain, e.g., "Could be UI element vs feature name", "Missing domain context"]

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docs-fix-changelog
-version: 2.0.0
-description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
+version: 2.1.0
+description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes confidence scoring and assumption tracking for suggestion transparency. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
 argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
 context: fork
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -56,6 +56,8 @@ To ensure fix suggestions align with the latest Elastic changelog standards, att
 
 **Purpose:** This ensures fix suggestions match the most current writer guidance. If successful, cross-check key patterns (title cleanup checklist, technical terms guidance, anti-patterns) against what's embedded in this skill. If there are significant discrepancies, note this in the final output.
 
+**Track for confidence:** Document whether canonical guidance was successfully fetched and which source was used. Failed fetches or fallback to embedded patterns should be noted as factors affecting suggestion confidence.
+
 ## Operating modes
 
 **Mode A — Improve an existing file.** The first argument is a path to a changelog YAML file that already exists. Read it, assess weak or missing fields, and suggest improvements.
@@ -81,6 +83,8 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 3. If `prs` or `issues` fields in the existing file (Mode A) contain URLs, use those as implicit context — they identify the PR or issue the changelog describes
 4. If none of the above is available, ask once: "Do you have context from a PR or issue (title, description, diff, or linked references) to share? Richer context produces better suggestions." Skip this ask if the user has already declined.
 
+**Track for confidence:** Document what context was available (full PR details, partial info, URLs only, or none) and any fetch failures. This will inform confidence scoring in Step 7.
+
 ## Step 4: Apply post-edit checklist
 
 **Before field-level assessment**, apply the systematic pattern checklist that mirrors the warnings from `docs-review-changelog`. This ensures consistent improvement patterns across both tools.
@@ -95,27 +99,22 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 - **No buried lede:** If title is vague, fold in concrete detail from description so release notes stand alone
 - **Base-form verb requirement:** Use `Fix`, `Add`, `Remove` (not third-person `Fixes`, `Adds`, `Removes`)
 - **Sentence case:** Follow standard sentence capitalization
+- Feature prefixes in titles: `ESQL: Fix nullify` should be contextual like `Fix nullify in ES|QL`
 
-**2. ES|QL contextual integration fixes:**
-
-- Avoid naked ES|QL or ESQL prefixes in titles: `ESQL: Fix nullify` should be contextual like `Fix nullify in ES|QL`
-- Standardize format: `ESQL` → `ES|QL`
-- When `areas` field already specifies "ES|QL", avoid redundant ES|QL in title
-
-**3. Technical term enhancement fixes:**
+**2. Technical term enhancement fixes:**
 
 - Add backticks around class/method names, config keys, API endpoints, or code identifiers where missing
 - Convert British spelling to US English: `serialise` → `serialize`, `colour` → `color`
 - Expand abbreviations where full form would be clearer: `params` → `parameters`
+- Standardize format: `ESQL` → `ES|QL`
 
-**4. Content quality fixes:**
+**3. Content quality fixes:**
 
 - Make vague titles more specific based on description content
 - Remove redundant descriptions that just repeat the title without adding context
-- Replace `UX` terminology with `UI` for interface changes
 - Focus on user-visible outcomes instead of implementation details
 
-**5. YAML formatting fixes:**
+**4. YAML formatting fixes:**
 
 - Quote text containing special characters (backticks, colons, brackets) to prevent parse errors
 - Ensure consistent formatting across text fields
@@ -145,6 +144,12 @@ Also check for formatting anti-patterns in existing `description`, `impact`, and
 ## Step 6: Generate suggestions
 
 **Character limits:** Title max 80 characters. Description max 600 characters. If a suggestion is too long, shorten it or split across title and description.
+
+**Confidence tracking:** During suggestion generation, note factors that affect confidence:
+
+- **High confidence:** Routine pattern fixes (development prefixes, obvious YAML quoting), standard terminology, good PR context
+- **Medium confidence:** Technical terms with contextual clues, partial PR context, common Elastic terminology
+- **Low confidence:** Domain-specific terms without context, missing PR details, ambiguous phrasing that could have multiple interpretations, novel or uncommon technical concepts
 
 **Mode A & B** — for each weak or malformed field, show:
 
@@ -213,6 +218,36 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 
 **Mode C:** Present the suggested field text, followed by the ready-to-copy `docs-builder changelog add` command. Invite the user to confirm or adjust before running the command. Make clear that the skill does not create the file — `changelog add` does.
 
-**All modes:** Default behavior is suggest-only. Only apply changes to disk after explicit user confirmation. After writing changes, re-parse YAML to validate the result.
+### Confidence and assumptions section
+
+**All modes:** After presenting suggestions but before requesting confirmation, include a structured "Confidence + Assumptions" section that helps writers evaluate suggestion quality:
+
+```markdown
+## Confidence + Assumptions
+
+### Least confident suggestions:
+- [Field]: [Specific suggestion] — [Reason for uncertainty, e.g., "Limited PR context", "Ambiguous technical term", "Multiple interpretation options"]
+
+### Terminology uncertainties:
+- [Term/phrase]: Assumed [interpretation] — [Why uncertain, e.g., "Could be UI element vs feature name", "Missing domain context"]
+
+### Assumptions made:
+- [Assumption]: [Rationale, e.g., "Normalized technical term based on common Elastic usage", "Inferred user impact from limited PR description"]
+
+### Input limitations:
+- [Issue]: [Impact on suggestions, e.g., "Couldn't fetch PR #1234 - title suggestions based on changelog content only", "No issue links - impact/action suggestions may be incomplete"]
+
+### Resources referenced:
+- [✓/✗] Canonical guidance: [Source used or fetch failure reason]
+- [✓/✗] PR/Issue context: [What was available or missing]
+```
+
+**Confidence scoring guidance:**
+
+- **Low confidence triggers:** Missing PR context, ambiguous technical terms, conflicting pattern interpretations, failed resource fetches, domain-specific terminology without clear context
+- **Medium confidence:** Partial PR context, standard technical terms, routine pattern fixes with good guidance
+- **High confidence:** Full context available, canonical guidance loaded, routine formatting/structural fixes
+
+**Default behavior:** Default behavior is suggest-only. Only apply changes to disk after explicit user confirmation. After writing changes, re-parse YAML to validate the result.
 
 **Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your output. Note which patterns may need updating and suggest checking the canonical source directly at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.

--- a/skills/changelogs/fix-changelog/evals/evals.json
+++ b/skills/changelogs/fix-changelog/evals/evals.json
@@ -4,11 +4,11 @@
     {
       "id": 1,
       "prompt": "Fix this changelog title that has UI formatting issues: 'Update Service Inventory page for better Machine Learning display'",
-      "expected_output": "Suggestion showing proper UI element formatting with **Service Inventory** bolded (UI label) but Machine Learning capitalized (feature name), not bolded",
+      "expected_output": "Suggestion showing proper UI element formatting with \"Service Inventory\" quoted (UI label) but Machine Learning capitalized (feature name), not quoted",
       "expectations": [
-        "Suggests bolding 'Service Inventory' as UI element: **Service Inventory**",
-        "Suggests capitalizing 'Machine Learning' as feature name (not bolding)",
-        "Includes article: 'the **Service Inventory** page'", 
+        "Suggests quoting 'Service Inventory' as UI element: \"Service Inventory\"",
+        "Suggests capitalizing 'Machine Learning' as feature name (not quoting)",
+        "Includes article: 'the \"Service Inventory\" page'", 
         "Explains UI vs feature name formatting distinction"
       ]
     },

--- a/skills/changelogs/fix-changelog/evals/evals.json
+++ b/skills/changelogs/fix-changelog/evals/evals.json
@@ -33,6 +33,19 @@
         "Provides rationale for formatting choice made",
         "Shows enhanced confidence methodology with assumption tracking"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "Fix changelog title with ambiguous acronym: 'fix: KI details flyout pushes page content in dark mode'. No PR context provided.",
+      "expected_output": "Flags 'KI' acronym expansion as uncertain, asks for clarification, and documents acronym uncertainty in confidence section rather than guessing the expansion",
+      "expectations": [
+        "Strips development prefix 'fix:' from title",
+        "Flags 'KI' acronym as requiring clarification rather than expanding to 'knowledge item'",
+        "Documents acronym uncertainty in 'Terminology uncertainties' confidence section",
+        "Asks user to clarify what 'KI' stands for in context request",
+        "References checking docs-flag-jargon-skill patterns for common acronyms",
+        "Shows medium/low confidence for acronym-related suggestions"
+      ]
     }
   ]
 }

--- a/skills/changelogs/fix-changelog/evals/evals.json
+++ b/skills/changelogs/fix-changelog/evals/evals.json
@@ -1,0 +1,38 @@
+{
+  "skill_name": "docs-fix-changelog",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Fix this changelog title that has UI formatting issues: 'Update Service Inventory page for better Machine Learning display'",
+      "expected_output": "Suggestion showing proper UI element formatting with **Service Inventory** bolded (UI label) but Machine Learning capitalized (feature name), not bolded",
+      "expectations": [
+        "Suggests bolding 'Service Inventory' as UI element: **Service Inventory**",
+        "Suggests capitalizing 'Machine Learning' as feature name (not bolding)",
+        "Includes article: 'the **Service Inventory** page'", 
+        "Explains UI vs feature name formatting distinction"
+      ]
+    },
+    {
+      "id": 2, 
+      "prompt": "Fix this changelog where accuracy conflicts with style: Title 'Improve dashboard performance' but PR shows it actually fixes a memory leak bug that was causing crashes",
+      "expected_output": "Suggestion prioritizes accuracy over style, recommending title change to reflect bug fix nature and possibly changing type to bug-fix",
+      "expectations": [
+        "Prioritizes factual accuracy over stylistic preference",
+        "Suggests title reflecting actual fix (memory leak/crashes) not generic improvement",
+        "May suggest type change to bug-fix if behavior was broken",
+        "Explains correctness priority principle in reasoning"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Fix changelog with uncertain formatting: 'Enable Advanced Settings in Kibana for index.refresh_interval configuration'",
+      "expected_output": "Confidence tracking documents uncertainty about 'Advanced Settings' (UI vs feature) and properly formats index.refresh_interval with backticks",
+      "expectations": [
+        "Uses backticks for config parameter: `index.refresh_interval`",
+        "Documents uncertainty about 'Advanced Settings' formatting in confidence section",
+        "Provides rationale for formatting choice made",
+        "Shows enhanced confidence methodology with assumption tracking"
+      ]
+    }
+  ]
+}

--- a/skills/changelogs/fix-changelog/evals/evals.json
+++ b/skills/changelogs/fix-changelog/evals/evals.json
@@ -46,6 +46,41 @@
         "References checking docs-flag-jargon-skill patterns for common acronyms",
         "Shows medium/low confidence for acronym-related suggestions"
       ]
+    },
+    {
+      "id": 5,
+      "prompt": "Fix changelog with feature prefix: 'File upload: Fixes disabling data view creation based on user capabilities'",
+      "expected_output": "Detects feature/app prefix pattern and suggests contextual integration alternatives using integration templates",
+      "expectations": [
+        "Detects 'File upload:' as feature/app prefix pattern",
+        "Suggests integrated alternative: 'Prevent data view creation in file upload tool without sufficient privileges'",
+        "Uses integration template: '[Feature]: Fix [issue]' → 'Fix [issue] in [feature]'",
+        "Shows high confidence for clear UI component name",
+        "Documents feature prefix suggestion in confidence section"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Fix changelog with technical colon usage: 'Fix bug with Auth header needing \"Authorization: Bearer <token>\"'",
+      "expected_output": "Correctly skips technical term and does NOT flag as feature prefix, focusing on other improvements",
+      "expectations": [
+        "Does NOT flag 'Authorization: Bearer' as feature prefix (correctly classified as API/technical term)",
+        "Focuses on other potential improvements (YAML quoting, formatting)",
+        "Shows understanding of legitimate colon usage patterns",
+        "Does not suggest prefix integration for technical content"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Fix changelog with ambiguous prefix: 'Security: Enable new authentication method'",
+      "expected_output": "Detects potential feature prefix but shows medium confidence due to ambiguous context",
+      "expectations": [
+        "Detects 'Security:' as potential feature prefix",
+        "Suggests integration: 'Enable new authentication method for security'",
+        "Shows medium confidence due to ambiguous feature name",
+        "Documents ambiguity in feature prefix confidence section",
+        "Uses integration template: '[Feature]: Enable [capability]' → 'Enable [capability] for [feature]'"
+      ]
     }
   ]
 }

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docs-review-changelog
-version: 1.0.2
-description: Validate and assess the quality of Elastic changelog YAML files. Reports schema errors, content quality issues, and formatting problems by type. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
+version: 1.2.0
+description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, and systematic pattern violations. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
 argument-hint: <file-or-directory>
 context: fork
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -28,19 +28,50 @@ under the License. -->
 
 You are a changelog reviewer for Elastic documentation. Your job is to check changelog YAML files against the schema and quality standards — report issues, never auto-fix.
 
+## How to use this skill
+
+**Purpose:** Quality gatekeeper for changelog YAML files. Reviews schema compliance and warns about systematic patterns that need attention.
+
+**Common workflows:**
+
+- **Review only:** Gate before merge ("check `docs/changelog`") — use when you want to validate files without making changes
+- **Review → fix → review:** *Recommended* for files with many issues. Use the review report as a punch list, then run `docs-fix-changelog` on specific files, then re-run review on the same path before merge
+- **Fix only:** If you already know specific files need wording improvements and want suggestions
+
+**Relationship to `docs-fix-changelog`:**
+
+- This skill **never modifies files** — it only reports issues
+- `docs-fix-changelog` **suggests improvements** for issues found by this skill
+- Both skills check the same systematic patterns but serve different purposes: review warns, fix suggests
+- **Directory support:** This skill supports directories (globs `*.yaml`/`*.yml` automatically)
+- **Optional workflow:** You don't have to run review before fix or vice versa — use whichever fits your needs
+
+**When to run `docs-fix-changelog` after review:** If this review surfaces quality warnings or formatting warnings, `docs-fix-changelog` can provide specific suggestions for improvement.
+
 ## Inputs
 
 `$ARGUMENTS` is a file path or directory to review. If empty, ask the user what to review.
 
-## Step 1: Discover and parse files
+## Step 1: Load canonical guidance (optional but recommended)
+
+To ensure this review aligns with the latest Elastic changelog standards, attempt to fetch the current guidance:
+
+1. **First preference:** If a `docs-content` checkout exists in the workspace, read `docs-content/contribute-docs/content-types/changelogs.md`
+2. **Second preference:** Fetch the published guide at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>
+3. **Fallback:** Use the embedded patterns in this skill (Steps 3-4) if the above sources are unavailable
+
+**Purpose:** This ensures the review warnings match the most current writer guidance. If successful, cross-check key patterns (title cleanup checklist, technical terms guidance, anti-patterns) against what's embedded in this skill. If there are significant discrepancies, note this in the final summary.
+
+## Step 2: Discover and parse files
 
 Glob for `*.yaml` and `*.yml` in `$ARGUMENTS`, or read a single file if given a direct path. Parse each file as YAML. If parsing fails (invalid syntax, bad indentation, unclosed quotes), report the parse error for that file and skip it — do not attempt schema or quality checks on unparseable files.
 
-## Step 2: Schema checks
+## Step 3: Schema checks
 
 These are hard errors. The source of truth for the schema is `ChangelogEntry.cs` linked in `sources`.
 
 **Required fields:**
+
 - `title`: must be present, max 80 characters
 - `type`: must be present, value must be one of: `feature`, `enhancement`, `security`, `bug-fix`, `breaking-change`, `deprecation`, `known-issue`, `docs`, `regression`, `other`
 - `products`: must be present, non-empty array; each entry must have a `product` key
@@ -56,20 +87,51 @@ These are hard errors. The source of truth for the schema is `ChangelogEntry.cs`
 - `feature-id` if present: must be a string — used to associate a change with a unique feature flag
 - `highlight` if present: must be a boolean — marks entries for inclusion in release highlights
 
-**YAML quoting:** Text field values (`title`, `description`, `impact`, `action`) that contain `: ` (colon followed by a space) MUST be wrapped in quotes — an unquoted value containing `: ` is interpreted as the start of a new mapping key and causes a "While scanning a plain scalar value, found invalid mapping" error at bundle time. Also flag unquoted values containing `#`, `[`, `]`, `{`, or `}` as these can also cause parse failures.
+**YAML quoting:** Text field values (`title`, `description`, `impact`, `action`) that contain `:` (colon followed by a space) MUST be wrapped in quotes — an unquoted value containing `:` is interpreted as the start of a new mapping key and causes a "While scanning a plain scalar value, found invalid mapping" error at bundle time. Also flag unquoted values containing `#`, `[`, `]`, `{`, or `}` as these can also cause parse failures.
 
 Example problem: `description: The tool no longer accepts the flag: -c`
 Correct form: `description: "The tool no longer accepts the flag: -c"`
 
-## Step 3: Quality checks
+## Step 4: Quality checks
 
 These are warnings. The source of truth is the changelogs style guidance linked in `sources`.
 
 **All types:**
-- Title starts with a present-tense action verb (`Adds`, `Fixes`, `Improves`, `Removes`, `Updates`…)
+- Title starts with base-form action verb (`Add`, `Fix`, `Improve`, `Remove`, `Update`…) — not third-person forms (`Adds`, `Fixes`)
 - Title is specific, not vague ("Bug fixes" or "Performance improvements" are too vague)
 - Title avoids bare internal references ("PR #123", "bug #456") — these don't help users
 - Title and description avoid implementation-focused language (describe user impact, not code changes)
+
+**Systematic pattern warnings:**
+
+**1. Title standardization issues (from canonical Title cleanup checklist):**
+
+- **Strip development labels:** Remove prefixes such as `feat:`, `fix:`, `Fix:`, `auto-implement:`, and trailing tracker fragments like `Bugfix -`
+- **No bracket-only team tags:** Replace `[Security Solution]`, `[Query Rules]`, `[Inference]`, and similar with plain, user-facing wording
+- **Strong verbs:** Prefer *Improve validation for...* over *Better validation for...* (use present tense imperative: Fix, Add, Remove)
+- **No buried lede:** If title is vague, fold in concrete detail from description so release notes stand alone
+- **Base-form verb requirement:** Use `Fix`, `Add`, `Remove` (not third-person `Fixes`, `Adds`, `Removes`)
+- **Sentence case:** Follow standard sentence capitalization
+
+**2. ES|QL contextual integration issues:**
+- Naked ES|QL or ESQL prefixes in titles: `ESQL: Fix nullify` should be contextual like `Fix nullify in ES|QL`
+- Inconsistent ES|QL format: `ESQL` should be standardized to `ES|QL`
+- When `areas` field already specifies "ES|QL", redundant ES|QL in title
+
+**3. Technical term enhancement issues:**
+- Missing backticks around class/method names, config keys, API endpoints, or code identifiers
+- British spelling that should use US English: `serialise` → `serialize`, `colour` → `color`
+- Unexpanded abbreviations where full form would be clearer: `params` → `parameters`
+
+**4. Content quality issues:**
+- Vague titles that could be more specific based on description content
+- Redundant descriptions that just repeat the title without adding context
+- `UX` terminology that should be `UI` for interface changes
+- Implementation-focused phrasing instead of user-visible outcomes
+
+**5. YAML formatting issues (cross-reference with Step 3):**
+- Unquoted text containing special characters (see Step 3 for details)
+- Inconsistent formatting across text fields
 
 **Type-specific:**
 - `breaking-change`: `impact` and `action` are REQUIRED — flag as errors if absent; `subtype` is strongly recommended
@@ -80,19 +142,28 @@ These are warnings. The source of truth is the changelogs style guidance linked 
 - `impact` if present: should explain scope and who is affected
 - `action` if present: should provide clear, prescriptive steps
 
-## Step 4: Formatting checks
+## Step 5: Formatting checks
 
-These are warnings. Check only `description`, `impact`, and `action` field values.
+These are warnings. Check `description`, `impact`, and `action` field values for formatting consistency.
 
+**Link formatting:**
 - Bare URLs used as link text — should use `[descriptive text](url)` instead
-- Code fences without a language identifier — e.g. ` ``` ` with no language tag
-- Field names, config keys, commands, or API endpoints written as plain text — should use inline backticks
+- Generic link text like "click here" or "read more" — should be descriptive of the destination
 
-## Step 5: Report
+**Code formatting:**
+- Code fences without a language identifier — e.g. ` ``` ` with no language tag (use `yaml`, `json`, `bash`, `console`, etc.)
+- Field names, config keys, commands, class names, or API endpoints written as plain text — should use inline backticks
+- Missing backticks around obvious code identifiers like method names, parameter names, or specific values
+
+**Text formatting:**
+- Inconsistent spelling (should follow US English conventions)
+- Inconsistent terminology (`UX` vs `UI` — prefer `UI` for interface changes)
+
+## Step 6: Report
 
 Produce one section per file reviewed. Omit empty sections. Use this format:
 
-```
+```markdown
 ## Changelog review: <filename>
 
 ### Summary
@@ -110,4 +181,6 @@ Produce one section per file reviewed. Omit empty sections. Use this format:
 
 If a file has no issues, say so explicitly.
 
-End with a one-line overall summary across all files reviewed. If any files have quality or formatting warnings, suggest running `docs-fix-changelog` to get suggested improvements.
+End with a one-line overall summary across all files reviewed. If any files have quality warnings (including systematic pattern issues) or formatting warnings, suggest running `docs-fix-changelog` to get specific improvement suggestions that address the same patterns this review identified.
+
+**Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your summary. Note which patterns may need updating and suggest checking the canonical source directly at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -146,9 +146,8 @@ These are warnings. The source of truth is the changelogs style guidance linked 
 
 **5. UI element formatting issues:**
 
-- **Missing bold on UI labels:** Button names, page titles, tabs should be **bolded**
-- **Missing articles:** Use "the **Overview** tab" not "**Overview** tab"
-- **Incorrectly bolded feature names:** Feature names should be capitalized, not bolded (Machine Learning, not **Machine Learning**)
+- **Unclear UI labels:** Button names, page titles, tabs should be in "quotation marks" if the phrase is unclear. For example: 'Fix "View in AI Assistant" button availability'
+- **Incorrectly quoted feature names:** Feature names should be capitalized, not quoted (Machine Learning, not "Machine Learning")
 - **Missing backticks:** Field names, parameters, API endpoints should use `backticks`
 - **UI vs feature uncertainty:** Flag when formatting choice between UI label and feature name is unclear
 

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docs-review-changelog
 version: 1.1.0
-description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, and systematic pattern violations. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
+description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, systematic pattern violations, and type-title alignment mismatches. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
 argument-hint: <file-or-directory>
 context: fork
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -79,6 +79,7 @@ These are hard errors. The source of truth for the schema is `ChangelogEntry.cs`
 **Product ID validation:** Fetch `https://raw.githubusercontent.com/elastic/docs-builder/main/config/products.yml` to get the canonical list — valid IDs are the top-level keys under `products:`. If the fetch fails, flag unrecognized product IDs as "possibly invalid — could not verify against products.yml" rather than as errors.
 
 **Optional field constraints:**
+
 - `products[n].lifecycle` if present on any product entry, fetch `https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/Lifecycle.cs` to get canonical list (such as `ga`)
 - `subtype`: only permitted on `breaking-change` entries; value must be one of: `api`, `behavioral`, `configuration`, `dependency`, `subscription`, `plugin`, `security`, `other`
 - `description` if present: max 600 characters
@@ -133,6 +134,31 @@ These are warnings. The source of truth is the changelogs style guidance linked 
 - Unquoted text containing special characters (see Step 2 for details)
 - Inconsistent formatting across text fields
 
+**5. Type-title alignment issues:**
+
+Flag when changelog `type` and `title` verb patterns don't align, indicating potential misclassification:
+
+- **`bug-fix`/`regression` misalignment:** Title uses `Improve`, `Enable`, `Update`, `Enhance` instead of expected `Fix`, `Resolve`, `Correct`
+  - **Warning:** Type suggests fixing broken behavior, but title implies improvement/addition
+  - **Suggest:** Review whether behavior was actually broken or if this should be `enhancement`
+
+- **`enhancement` misalignment:** Title uses `Fix`, `Resolve`, `Correct` instead of expected `Improve`, `Update`, `Optimize`, `Enable`, `Expand`, `Enhance`
+  - **Warning:** Type suggests improving working functionality, but title implies fixing broken behavior
+  - **Suggest:** Review whether behavior was broken (→ `bug-fix`) or truly an optimization (keep `enhancement`)
+
+- **`feature` misalignment:** Title uses `Fix`, `Improve` for substantial new capabilities
+  - **Warning:** Major new functionality should use `Add`, `Introduce`, `Enable`, `Support`
+  - **Suggest:** Review scope - substantial new capability (→ `feature`) vs minor addition (→ `enhancement`)
+
+- **`docs` misalignment:** Title doesn't focus on documentation clarity/accuracy
+  - **Warning:** Documentation changes should use `Update`, `Add`, `Clarify`, `Document`
+
+**Example patterns to flag:**
+
+- Type `bug-fix` + "Improve query approximation accuracy..." → **Flag alignment mismatch**
+- Type `enhancement` + "Fix Painless score scripts..." → **Flag alignment mismatch**  
+- Type `enhancement` + "Fix ES|QL performance issues..." → **Flag alignment mismatch**
+
 **Type-specific:**
 
 - `breaking-change`: `impact` and `action` are REQUIRED — flag as errors if absent; `subtype` is strongly recommended
@@ -185,6 +211,6 @@ Produce one section per file reviewed. Omit empty sections. Use this format:
 
 If a file has no issues, say so explicitly.
 
-End with a one-line overall summary across all files reviewed. If any files have quality warnings (including systematic pattern issues) or formatting warnings, suggest running `docs-fix-changelog` to get specific improvement suggestions that address the same patterns this review identified.
+End with a one-line overall summary across all files reviewed. If any files have quality warnings (including systematic pattern issues and type-title alignment mismatches) or formatting warnings, suggest running `docs-fix-changelog` to get specific improvement suggestions that address the same patterns this review identified.
 
 **Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your summary. Note which patterns may need updating and suggest checking the canonical source directly at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -28,6 +28,8 @@ under the License. -->
 
 You are a changelog reviewer for Elastic documentation. Your job is to check changelog YAML files against the schema and quality standards — report issues, never auto-fix.
 
+**Target audience:** Power users who can follow PR links for details. **Correctness priority:** Accuracy always takes precedence over style.
+
 ## How to use this skill
 
 **Purpose:** Quality gatekeeper for changelog YAML files. Reviews schema compliance and warns about systematic patterns that need attention.
@@ -67,6 +69,8 @@ To ensure review warnings align with current standards and repository-specific r
 3. **Fallback:** If no repository config found, note this limitation in the final summary
 
 **Purpose:** This ensures review warnings match both current writer guidance and repository-specific validation rules. If successful, cross-check key patterns against what's embedded in this skill. If there are significant discrepancies, note this in the final summary.
+
+**Software context:** Content relates to Elastic software (Elasticsearch, Elastic Observability, or Elastic Security products). Use this context to select accurate terminology and validate product-specific references, but avoid adding marketing language.
 
 ## Step 2: Discover and parse files
 
@@ -139,6 +143,14 @@ These are warnings. The source of truth is the changelogs style guidance linked 
 
 - Unquoted text containing special characters (see Step 2 for details)
 - Inconsistent formatting across text fields
+
+**5. UI element formatting issues:**
+
+- **Missing bold on UI labels:** Button names, page titles, tabs should be **bolded**
+- **Missing articles:** Use "the **Overview** tab" not "**Overview** tab"
+- **Incorrectly bolded feature names:** Feature names should be capitalized, not bolded (Machine Learning, not **Machine Learning**)
+- **Missing backticks:** Field names, parameters, API endpoints should use `backticks`
+- **UI vs feature uncertainty:** Flag when formatting choice between UI label and feature name is unclear
 
 **5. Type-title alignment issues:**
 
@@ -233,6 +245,14 @@ Produce one section per file reviewed. Omit empty sections. Use this format:
 ```
 
 If a file has no issues, say so explicitly.
+
+### Confidence Assessment
+Include this section when resource loading or validation has limitations:
+
+- **Canonical guidance:** [✓ Loaded successfully | ✗ Failed - using embedded patterns]
+- **Repository config:** [✓ Found docs/changelog.yml | ✗ Not found - using generic validation]  
+- **Validation confidence:** [High | Medium | Low] - [Brief reason]
+- **Review limitations:** [Any factors affecting review accuracy]
 
 End with a one-line overall summary across all files reviewed. If any files have quality warnings (including systematic pattern issues, type-title alignment mismatches, and technical content issues) or formatting warnings, suggest running `docs-fix-changelog` to get specific improvement suggestions that address the same patterns this review identified.
 

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -124,7 +124,7 @@ These are warnings. The source of truth is the changelogs style guidance linked 
 - **No buried lede:** If title is vague, fold in concrete detail from description so release notes stand alone
 - **Base-form verb requirement:** Use `Fix`, `Add`, `Remove` (not third-person `Fixes`, `Adds`, `Removes`)
 - **Sentence case:** Follow standard sentence capitalization
-- Feature prefixes in titles: `ESQL: Fix nullify` should be contextual like `Fix nullify in ES|QL`
+- **Feature/app prefix patterns:** Flag titles with `[Feature/App]: [Action]` patterns that need contextual integration (e.g., "File upload: Fix bug" should integrate the feature contextually). Skip technical terms, API references, code identifiers.
 
 **2. Technical term enhancement issues:**
 

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-review-changelog
-version: 1.4.0
+version: 1.4.1
 description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, systematic pattern violations, type-title alignment mismatches, and overly technical content that needs user-focused rewrites. Features repository-aware area validation. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
 argument-hint: <file-or-directory>
 context: fork
@@ -78,11 +78,11 @@ Glob for `*.yaml` and `*.yml` in `$ARGUMENTS`, or read a single file if given a 
 
 ## Step 3: Schema checks
 
-These are hard errors. The source of truth for the schema is `ChangelogEntry.cs` linked in `sources`.
+These are hard errors — structural/parse failures only (missing required fields, invalid enums, YAML types, unquoted scalars, required `impact`/`action` on `breaking-change`). Not style guidelines. The source of truth for the schema is `ChangelogEntry.cs` linked in `sources`.
 
 **Required fields:**
 
-- `title`: must be present, preferrably under 80 characters
+- `title`: must be present
 - `type`: must be present, value must be one of: `feature`, `enhancement`, `security`, `bug-fix`, `breaking-change`, `deprecation`, `known-issue`, `docs`, `regression`, `other`
 - `products`: must be present, non-empty array; each entry must have a `product` key
 
@@ -92,7 +92,6 @@ These are hard errors. The source of truth for the schema is `ChangelogEntry.cs`
 
 - `products[n].lifecycle` if present on any product entry, fetch `https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/Lifecycle.cs` to get canonical list (such as `ga`)
 - `subtype`: only permitted on `breaking-change` entries; value must be one of: `api`, `behavioral`, `configuration`, `dependency`, `subscription`, `plugin`, `security`, `other`
-- `description` if present: max 600 characters
 - `prs` and `issues`: optional arrays, may be empty or absent — no validation beyond YAML type correctness
 - `areas` if present: must be an array of strings — validate against repository configuration from Step 1 if available (only flag areas not in `docs/changelog.yml` pivot.areas section), otherwise use generic validation
 - `feature-id` if present: must be a string — used to associate a change with a unique feature flag
@@ -113,6 +112,7 @@ These are warnings. The source of truth is the changelogs style guidance linked 
 - Title is specific, not vague ("Bug fixes" or "Performance improvements" are too vague)
 - Title avoids bare internal references ("PR #123", "bug #456") — these don't help users
 - Title and description avoid implementation-focused language (describe user impact, not code changes)
+- Title over 80 or description over 600 characters → quality warning (guideline; low priority if ≤20 over; never a merge blocker)
 
 **Systematic pattern warnings:**
 
@@ -136,7 +136,7 @@ These are warnings. The source of truth is the changelogs style guidance linked 
 **3. Content quality issues:**
 
 - Vague titles that could be more specific based on description content
-- Redundant descriptions that just repeat the title without adding context
+- Absent `description` when title is self-explanatory is fine; only flag **present** descriptions that repeat the title, say "See PR", or add no context
 - Implementation-focused phrasing instead of user-visible outcomes
 
 **4. YAML formatting issues (cross-reference with Step 2):**
@@ -199,7 +199,7 @@ Flag overly technical titles that focus on implementation details rather than us
 - `deprecation` and `known-issue`: `impact` and/or `action` are recommended — flag as warnings if absent
 - `feature` / `enhancement`: title/description should explain what users can now do, not how it was built
 - `bug-fix` / `regression`: title/description should explain what was wrong and what is now correct
-- `description` if present: must add context beyond repeating the title; flagging "See PR" or "Internal refactoring" as low-value
+- When present, `description` must add context beyond repeating the title; flagging "See PR" or "Internal refactoring" as low-value
 - `impact` if present: should explain scope and who is affected
 - `action` if present: should provide clear, prescriptive steps
 

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docs-review-changelog
-version: 1.1.0
-description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, systematic pattern violations, and type-title alignment mismatches. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
+version: 1.4.0
+description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, systematic pattern violations, type-title alignment mismatches, and overly technical content that needs user-focused rewrites. Features repository-aware area validation. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
 argument-hint: <file-or-directory>
 context: fork
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -52,15 +52,21 @@ You are a changelog reviewer for Elastic documentation. Your job is to check cha
 
 `$ARGUMENTS` is a file path or directory to review. If empty, ask the user what to review.
 
-## Step 1: Load canonical guidance (optional but recommended)
+## Step 1: Load canonical guidance and repository configuration
 
-To ensure this review aligns with the latest Elastic changelog standards, attempt to fetch the current guidance:
+To ensure review warnings align with current standards and repository-specific rules:
 
+### Canonical Guidance Loading
 1. **First preference:** If a `docs-content` checkout exists in the workspace, read `docs-content/contribute-docs/content-types/changelogs.md`
 2. **Second preference:** Fetch the published guide at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>
-3. **Fallback:** Use the embedded patterns in this skill (Steps 3-4) if the above sources are unavailable
+3. **Fallback:** Use the embedded patterns in this skill if the above sources are unavailable
 
-**Purpose:** This ensures the review warnings match the most current writer guidance. If successful, cross-check key patterns (title cleanup checklist, technical terms guidance, anti-patterns) against what's embedded in this skill. If there are significant discrepancies, note this in the final summary.
+### Repository Configuration Loading
+1. **Area validation:** Look for `docs/changelog.yml` in the workspace to extract valid area values from the `pivot.areas` section
+2. **Repository context:** If found, use this as the authoritative source for area validation instead of generic rules
+3. **Fallback:** If no repository config found, note this limitation in the final summary
+
+**Purpose:** This ensures review warnings match both current writer guidance and repository-specific validation rules. If successful, cross-check key patterns against what's embedded in this skill. If there are significant discrepancies, note this in the final summary.
 
 ## Step 2: Discover and parse files
 
@@ -84,7 +90,7 @@ These are hard errors. The source of truth for the schema is `ChangelogEntry.cs`
 - `subtype`: only permitted on `breaking-change` entries; value must be one of: `api`, `behavioral`, `configuration`, `dependency`, `subscription`, `plugin`, `security`, `other`
 - `description` if present: max 600 characters
 - `prs` and `issues`: optional arrays, may be empty or absent — no validation beyond YAML type correctness
-- `areas` if present: must be an array of strings — denotes the parts/components/services of the product specifically affected
+- `areas` if present: must be an array of strings — validate against repository configuration from Step 1 if available (only flag areas not in `docs/changelog.yml` pivot.areas section), otherwise use generic validation
 - `feature-id` if present: must be a string — used to associate a change with a unique feature flag
 - `highlight` if present: must be a boolean — marks entries for inclusion in release highlights
 
@@ -159,6 +165,23 @@ Flag when changelog `type` and `title` verb patterns don't align, indicating pot
 - Type `enhancement` + "Fix Painless score scripts..." → **Flag alignment mismatch**  
 - Type `enhancement` + "Fix ES|QL performance issues..." → **Flag alignment mismatch**
 
+**6. Technical content issues:**
+
+Flag overly technical titles that focus on implementation details rather than user impact:
+
+- **Implementation-focused titles:** Class names, method names, or internal processes without user context
+  - **Warning:** Title focuses on code changes rather than user-visible symptoms
+  - **Example:** "Fix splitValue nullability coercion when constructing ColorSeries" → Flag as too technical
+  - **Suggest:** Rewrite to describe user-visible impact like "Fix inline charts with grey time series for ES|QL queries"
+
+- **Technical jargon without context:** Multiple technical terms that don't explain user experience
+  - **Warning:** Title requires deep technical knowledge to understand user impact
+  - **Suggest:** Focus on what users see, not how code works
+
+- **Missing user symptoms:** Describes internal fixes without explaining external effects
+  - **Warning:** Users can't determine if this change affects them
+  - **Suggest:** Include user-facing symptoms or feature areas affected
+
 **Type-specific:**
 
 - `breaking-change`: `impact` and `action` are REQUIRED — flag as errors if absent; `subtype` is strongly recommended
@@ -211,6 +234,6 @@ Produce one section per file reviewed. Omit empty sections. Use this format:
 
 If a file has no issues, say so explicitly.
 
-End with a one-line overall summary across all files reviewed. If any files have quality warnings (including systematic pattern issues and type-title alignment mismatches) or formatting warnings, suggest running `docs-fix-changelog` to get specific improvement suggestions that address the same patterns this review identified.
+End with a one-line overall summary across all files reviewed. If any files have quality warnings (including systematic pattern issues, type-title alignment mismatches, and technical content issues) or formatting warnings, suggest running `docs-fix-changelog` to get specific improvement suggestions that address the same patterns this review identified.
 
 **Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your summary. Note which patterns may need updating and suggest checking the canonical source directly at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -72,14 +72,14 @@ These are hard errors. The source of truth for the schema is `ChangelogEntry.cs`
 
 **Required fields:**
 
-- `title`: must be present, max 80 characters
+- `title`: must be present, preferrably under 80 characters
 - `type`: must be present, value must be one of: `feature`, `enhancement`, `security`, `bug-fix`, `breaking-change`, `deprecation`, `known-issue`, `docs`, `regression`, `other`
 - `products`: must be present, non-empty array; each entry must have a `product` key
 
 **Product ID validation:** Fetch `https://raw.githubusercontent.com/elastic/docs-builder/main/config/products.yml` to get the canonical list — valid IDs are the top-level keys under `products:`. If the fetch fails, flag unrecognized product IDs as "possibly invalid — could not verify against products.yml" rather than as errors.
 
 **Optional field constraints:**
-- `products[n].lifecycle` if present on any product entry: must be `preview`, `beta`, or `ga`
+- `products[n].lifecycle` if present on any product entry, fetch `https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/Lifecycle.cs` to get canonical list (such as `ga`)
 - `subtype`: only permitted on `breaking-change` entries; value must be one of: `api`, `behavioral`, `configuration`, `dependency`, `subscription`, `plugin`, `security`, `other`
 - `description` if present: max 600 characters
 - `prs` and `issues`: optional arrays, may be empty or absent — no validation beyond YAML type correctness
@@ -97,6 +97,7 @@ Correct form: `description: "The tool no longer accepts the flag: -c"`
 These are warnings. The source of truth is the changelogs style guidance linked in `sources`.
 
 **All types:**
+
 - Title starts with base-form action verb (`Add`, `Fix`, `Improve`, `Remove`, `Update`…) — not third-person forms (`Adds`, `Fixes`)
 - Title is specific, not vague ("Bug fixes" or "Performance improvements" are too vague)
 - Title avoids bare internal references ("PR #123", "bug #456") — these don't help users
@@ -112,28 +113,28 @@ These are warnings. The source of truth is the changelogs style guidance linked 
 - **No buried lede:** If title is vague, fold in concrete detail from description so release notes stand alone
 - **Base-form verb requirement:** Use `Fix`, `Add`, `Remove` (not third-person `Fixes`, `Adds`, `Removes`)
 - **Sentence case:** Follow standard sentence capitalization
+- Feature prefixes in titles: `ESQL: Fix nullify` should be contextual like `Fix nullify in ES|QL`
 
-**2. ES|QL contextual integration issues:**
-- Naked ES|QL or ESQL prefixes in titles: `ESQL: Fix nullify` should be contextual like `Fix nullify in ES|QL`
-- Inconsistent ES|QL format: `ESQL` should be standardized to `ES|QL`
-- When `areas` field already specifies "ES|QL", redundant ES|QL in title
+**2. Technical term enhancement issues:**
 
-**3. Technical term enhancement issues:**
 - Missing backticks around class/method names, config keys, API endpoints, or code identifiers
 - British spelling that should use US English: `serialise` → `serialize`, `colour` → `color`
 - Unexpanded abbreviations where full form would be clearer: `params` → `parameters`
+- Inconsistent terminology: `ESQL` should be standardized to `ES|QL`
 
-**4. Content quality issues:**
+**3. Content quality issues:**
+
 - Vague titles that could be more specific based on description content
 - Redundant descriptions that just repeat the title without adding context
-- `UX` terminology that should be `UI` for interface changes
 - Implementation-focused phrasing instead of user-visible outcomes
 
-**5. YAML formatting issues (cross-reference with Step 3):**
-- Unquoted text containing special characters (see Step 3 for details)
+**4. YAML formatting issues (cross-reference with Step 2):**
+
+- Unquoted text containing special characters (see Step 2 for details)
 - Inconsistent formatting across text fields
 
 **Type-specific:**
+
 - `breaking-change`: `impact` and `action` are REQUIRED — flag as errors if absent; `subtype` is strongly recommended
 - `deprecation` and `known-issue`: `impact` and/or `action` are recommended — flag as warnings if absent
 - `feature` / `enhancement`: title/description should explain what users can now do, not how it was built
@@ -147,17 +148,20 @@ These are warnings. The source of truth is the changelogs style guidance linked 
 These are warnings. Check `description`, `impact`, and `action` field values for formatting consistency.
 
 **Link formatting:**
+
 - Bare URLs used as link text — should use `[descriptive text](url)` instead
 - Generic link text like "click here" or "read more" — should be descriptive of the destination
 
 **Code formatting:**
+
 - Code fences without a language identifier — e.g. ` ``` ` with no language tag (use `yaml`, `json`, `bash`, `console`, etc.)
 - Field names, config keys, commands, class names, or API endpoints written as plain text — should use inline backticks
 - Missing backticks around obvious code identifiers like method names, parameter names, or specific values
 
 **Text formatting:**
+
 - Inconsistent spelling (should follow US English conventions)
-- Inconsistent terminology (`UX` vs `UI` — prefer `UI` for interface changes)
+- Inconsistent terminology
 
 ## Step 6: Report
 

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-review-changelog
-version: 1.2.0
+version: 1.1.0
 description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, and systematic pattern violations. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
 argument-hint: <file-or-directory>
 context: fork

--- a/skills/changelogs/review-changelog/evals/evals.json
+++ b/skills/changelogs/review-changelog/evals/evals.json
@@ -33,6 +33,39 @@
         "Notes 'Medium' or 'Low' validation confidence due to missing resources",
         "Explains review limitations due to resource loading failures"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "Review changelog with feature prefix pattern: title: 'File upload: Fixes disabling data view creation based on user capabilities'",
+      "expected_output": "Flags feature/app prefix pattern as title standardization issue requiring contextual integration",
+      "expectations": [
+        "Flags 'File upload:' prefix pattern as title standardization issue",
+        "Categorizes under 'Feature/app prefix patterns' warning",
+        "Explains pattern needs contextual integration",
+        "Notes pattern should be handled by fix-changelog skill for solutions"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Review changelog with technical colon usage: title: 'Fix bug with Auth header needing \"Authorization: Bearer <token>\"'",
+      "expected_output": "Correctly does NOT flag technical term as feature prefix, focuses on other potential issues",
+      "expectations": [
+        "Does NOT flag 'Authorization: Bearer' as feature prefix pattern",
+        "Correctly identifies as legitimate technical/API reference",
+        "May flag other issues (YAML quoting, formatting) if present",
+        "Shows understanding of technical vs feature prefix distinction"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Review changelog with multiple title issues including feature prefix: title: 'Dashboard: fixes widget loading bugs'",
+      "expected_output": "Flags both feature prefix pattern AND other title issues (verb form, capitalization)",
+      "expectations": [
+        "Flags 'Dashboard:' as feature/app prefix pattern requiring integration",
+        "Flags verb form issue: 'fixes' should be 'Fix' (base form)",
+        "Notes title standardization issues in systematic order",
+        "Demonstrates comprehensive title pattern checking"
+      ]
     }
   ]
 }

--- a/skills/changelogs/review-changelog/evals/evals.json
+++ b/skills/changelogs/review-changelog/evals/evals.json
@@ -1,0 +1,38 @@
+{
+  "skill_name": "docs-review-changelog", 
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Review this changelog with UI formatting issues: title: 'Update Service Inventory to improve **Machine Learning** display' description: 'Changes to Advanced Settings panel'",
+      "expected_output": "Flags UI formatting issues: Service Inventory should be bolded, Machine Learning shouldn't be bolded (feature name), Advanced Settings panel formatting unclear",
+      "expectations": [
+        "Flags missing bold on 'Service Inventory' (UI element)",
+        "Flags incorrect bolding of 'Machine Learning' (should be feature name, not bolded)",
+        "Notes uncertainty about 'Advanced Settings panel' formatting",
+        "Includes UI element formatting issues in warnings"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Review changelog with Elastic context issues: title: 'Add support for ESQL queries in Observability' description: 'Enables ESQL functionality for monitoring use cases'", 
+      "expected_output": "Applies Elastic software context to validate ES|QL terminology and Observability product reference",
+      "expectations": [
+        "Notes inconsistent 'ESQL' format (should be 'ES|QL')",
+        "Validates 'Observability' as legitimate Elastic product context", 
+        "Shows software context awareness in terminology checking",
+        "Does not flag legitimate Elastic product references as marketing"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Review changelog when canonical guidance fails to load: title: 'Fix dashboard loading' with repository config not found",
+      "expected_output": "Includes confidence assessment showing failed resource loading and its impact on review accuracy", 
+      "expectations": [
+        "Includes 'Confidence Assessment' section in output",
+        "Shows '✗ Failed' status for canonical guidance or repository config", 
+        "Notes 'Medium' or 'Low' validation confidence due to missing resources",
+        "Explains review limitations due to resource loading failures"
+      ]
+    }
+  ]
+}

--- a/skills/changelogs/review-changelog/evals/evals.json
+++ b/skills/changelogs/review-changelog/evals/evals.json
@@ -4,10 +4,10 @@
     {
       "id": 1,
       "prompt": "Review this changelog with UI formatting issues: title: 'Update Service Inventory to improve **Machine Learning** display' description: 'Changes to Advanced Settings panel'",
-      "expected_output": "Flags UI formatting issues: Service Inventory should be bolded, Machine Learning shouldn't be bolded (feature name), Advanced Settings panel formatting unclear",
+      "expected_output": "Flags UI formatting issues: Service Inventory should be quoted, Machine Learning shouldn't be bolded or quoted (feature name), Advanced Settings panel formatting unclear",
       "expectations": [
-        "Flags missing bold on 'Service Inventory' (UI element)",
-        "Flags incorrect bolding of 'Machine Learning' (should be feature name, not bolded)",
+        "Flags missing quotes on 'Service Inventory' (UI element)",
+        "Flags incorrect quoting of 'Machine Learning' (should be feature name, not quoted)",
         "Notes uncertainty about 'Advanced Settings panel' formatting",
         "Includes UI element formatting issues in warnings"
       ]


### PR DESCRIPTION
This PR improves the skill that review and fix changelog files.
It'll be followed by the removal of the redundant serverless-specific changelog skill.

## Highlights

1. **Added comprehensive workflow documentation**:
   - **"How to use this skill"** section explaining purpose and common workflows
   - **Relationship to `docs-fix-changelog`** - clarifies that review warns, fix suggests
   - **Optional workflow** guidance (review/fix order is flexible)

2. **Updated quality checks**:
   - **Fixed verb forms**: Changed from third-person (`Adds`, `Fixes`) to base-form (`Add`, `Fix`) to match `changelogs.md`
   - **Added systematic pattern categories**:
     1. **Title standardization**: Remove dev prefixes, component brackets, fix verb forms, sentence case
     2. **Technical term enhancement**: Backticks for code identifiers, US spelling, expand abbreviations  
     3. **Content quality**: Vague titles, redundant descriptions, UX → UI, user-visible outcomes
     4. **YAML formatting**: Cross-references existing Step 2 quoting rules
     5. **Acronym handling**: Indicate assumptions and confidence when guessing meaning of acronym

3. **Documentation fallback mechanism**: The skill now tries to fetch current guidance in this order:
   - Local `docs-content/contribute-docs/content-types/changelogs.md`
   - Published guide at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>
   - Fallback to embedded patterns
   
4. **Sync awareness warnings**: The skill will flag discrepancies between live documentation and its embedded patterns

7. **Confidence Scoring**: Added confidence factors to make it clearer when there are high- or low-confidence suggestions.

8. **Repository-Aware Area Validation**: Use `docs/changelog.yml` configuration when available. This affects things like the checking the changelog has valid `areas`.

## Testing

Here's an example of the type of output it provided when I ran it against the files in https://github.com/elastic/kibana/pull/269376

### review-changelog

The changelog review has been completed for all 38 files with `target: 2026-05-12`. Here's the summary of remaining issues...

**Schema Issues (3 files):**
- **Title length violations**: 3 files have titles over 80 characters
  - `262628.yaml`: 96 characters
  - `266517.yaml`: 97 characters  
  - `267321.yaml`: 125 characters

**Quality Warnings (18 files):**
- **Missing deprecation guidance**: `261591.yaml` needs `impact`/`action` fields
- **Type-title alignment mismatches**: Multiple files use verbs that don't match their changelog type
- **Vague titles**: Several files need more specific descriptions
- **Technical/implementation-focused language**: Multiple entries focus on code rather than user impact

**Formatting Warnings (4 files):**
- **British spelling**: `262217.yaml` uses "grey" instead of "gray"
- **Missing punctuation**: `266184.yaml` lacks closing punctuation
- **Code identifiers**: `266630.yaml` needs backticks around constant names
- **Trailing whitespace**: `268434.yaml` has trailing space

##### Most Critical Issues to Address

1. **`261591.yaml`** - Deprecation entry missing migration guidance
2. **`262628.yaml`, `266517.yaml`, `267321.yaml`** - Titles too long for readability
3. **Multiple files** - Type-title verb alignment issues that could confuse classification

The review validates that all area values match the repository's `docs/changelog.yml` configuration, and all product IDs are valid per the canonical products list.

...

### fix-changelog

... I've identified several files that still need improvements. Here are the suggested fixes:

#### **267333.yaml** - Type: enhancement

**Current title:** `Introduce an optional configuration for Agent Builder Agents: connector_ids.`

**Suggested title:** `"Add connector-specific access control for Agent Builder agents"`

**Current description:** `'If unset, a given agent has access to all configured Kibana connectors. When set, the Agent will have access only to the listed connectors.'`

**Suggested description:** `"Agents can now be configured to access only specific connectors using the connector_ids setting. If unset, agents have access to all configured Kibana connectors."`

**Issues fixed:**
- Changed fragment to imperative verb "Add"
- Made title more user-focused and scannable
- Improved description flow and clarity
- Removed trailing period from title
- Used backticks for `connector_ids` setting name

---

#### **257284.yaml** - Type: enhancement

**Current title:** `Custom cases workflow triggers`

**Suggested title:** `"Add custom workflow triggers for cases"`

**Issues fixed:**
- Added imperative verb "Add" 
- Made title more action-oriented

---

#### **268170.yaml** - Type: bug-fix

**Current title:** `Cap window size`

**Suggested title:** `"Fix window size limits in [component name]"`

**Issues fixed:**
- Added context about what component this affects

**Note:** I need more context about which window/component this affects. Could you clarify which UI component or feature this relates to?

---

#### **268220.yaml** - Type: bug-fix

**Current title:** `Handle null titles`

**Suggested title:** `"Fix null title handling in dashboard panels"`

**Issues fixed:**
- Made specific to the affected component
- Used "Fix" instead of generic "Handle"

**Note:** I'm assuming this affects dashboard panels based on the areas field. Please confirm if this is correct.

---

...

#### Confidence + Assumptions

##### Medium confidence suggestions:
- **268170.yaml**: "Fix window size limits" — Limited context about which specific window/component is affected
- **268220.yaml**: "dashboard panels" — Inferred from areas field, but component could be different

##### High confidence suggestions:
- **263117.yaml**: Base-form verb and capitalization fixes based on clear style guide rules
- **267333.yaml**: Title restructuring follows standard imperative pattern
- **262217.yaml**: Code identifier formatting per technical terms guidance
- **266590.yaml**: Capitalization standardization

##### Terminology assumptions:
- **ColorSeries**: Assumed to be a class name based on PascalCase formatting
- **connector_ids**: Treated as configuration setting name based on description context

#### Resources referenced:
- ✅ Canonical guidance: Successfully fetched from elastic.co/docs/contribute-docs/content-types/changelogs  
- ✅ PR/Issue context: Available via URLs in most files but not fetched for detailed content

...

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: composer-2, claude-4-sonnet-thinking