### PR TITLE
Improve fix-changelog

### DIFF
--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: docs-fix-changelog
-version: 1.0.2
-description: Suggest improved text for weak or missing fields in Elastic changelog YAML files. Accepts optional PR or issue context (title, description, diff, linked issues) to produce better suggestions. Use after docs-review-changelog identifies quality issues, or when drafting a new changelog from a PR or issue.
-argument-hint: "[changelog-file] [pr/issue-context]"
+version: 2.0.0
+description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
+argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
 context: fork
-allowed-tools: Read, Grep, Glob
+allowed-tools: Read, Grep, Glob, WebFetch
 sources:
   - https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs
   - https://www.elastic.co/docs/contribute-docs/content-types/changelogs
@@ -30,20 +30,49 @@ under the License. -->
 
 You are a changelog writing assistant for Elastic documentation. You suggest improved text for changelog fields and help draft content for new changelogs. You do not create files — file creation is always done via `docs-builder changelog add`.
 
+## How to use this skill
+
+This skill pairs with `docs-review-changelog` as part of a systematic changelog improvement workflow:
+
+1. **Review first:** Use `docs-review-changelog` to identify schema errors, quality warnings, and systematic pattern violations
+2. **Fix second:** Use this skill to get specific improvement suggestions that address the same pattern catalog
+3. **Optional iteration:** Run both tools again before merge for final validation
+
+**Common workflows:**
+
+- **Single file:** `/docs-fix-changelog path/to/changelog.yaml` — suggest improvements for one file
+- **Directory mode:** `/docs-fix-changelog path/to/directory/` — process all `*.yaml` and `*.yml` files in the directory
+- **New changelog:** `/docs-fix-changelog "Create new changelog for: [PR context]"` — suggest content for a new changelog
+
+**Default behavior:** Suggest-only mode. Changes are only applied to disk after explicit user confirmation.
+
+## Step 1: Load canonical guidance (recommended)
+
+To ensure fix suggestions align with the latest Elastic changelog standards, attempt to fetch current guidance:
+
+1. **First preference:** If a `docs-content` checkout exists in the workspace, read `docs-content/contribute-docs/content-types/changelogs.md`
+2. **Second preference:** Fetch the published guide at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>
+3. **Fallback:** Use the embedded post-edit checklist in this skill (Steps 3-4) if the above sources are unavailable
+
+**Purpose:** This ensures fix suggestions match the most current writer guidance. If successful, cross-check key patterns (title cleanup checklist, technical terms guidance, anti-patterns) against what's embedded in this skill. If there are significant discrepancies, note this in the final output.
+
 ## Operating modes
 
 **Mode A — Improve an existing file.** The first argument is a path to a changelog YAML file that already exists. Read it, assess weak or missing fields, and suggest improvements.
 
-**Mode B — Suggest content for a new file.** No file path is given (or the argument doesn't resolve to a readable file). Suggest text for the text-based fields that the user can pass to `docs-builder changelog add`.
+**Mode B — Process directory.** The first argument is a path to a directory containing changelog files. Process all `*.yaml` and `*.yml` files in that directory, suggesting improvements for each.
 
-Detect mode automatically: if the first argument resolves to a readable file, use Mode A. Otherwise, use Mode B.
+**Mode C — Suggest content for a new file.** No file path is given, or the argument doesn't resolve to a readable file or directory. Suggest text for the text-based fields that the user can pass to `docs-builder changelog add`.
 
-## Step 1: Determine mode and read input
+Detect mode automatically: if the first argument resolves to a readable file, use Mode A. If it resolves to a directory, use Mode B. Otherwise, use Mode C.
+
+## Step 2: Determine mode and read input
 
 - **Mode A**: Read and parse the changelog file. If YAML parsing fails, report the error and stop.
-- **Mode B**: No file to read. Proceed to Step 2.
+- **Mode B**: Glob for `*.yaml` and `*.yml` files in the directory. Parse each file as YAML. If parsing fails for any file, report the error for that file but continue processing others.
+- **Mode C**: No file to read. Proceed to Step 3.
 
-## Step 2: Resolve PR/issue context
+## Step 3: Resolve PR/issue context
 
 Context from a PR or issue produces better suggestions. Use it in this order:
 
@@ -52,9 +81,48 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 3. If `prs` or `issues` fields in the existing file (Mode A) contain URLs, use those as implicit context — they identify the PR or issue the changelog describes
 4. If none of the above is available, ask once: "Do you have context from a PR or issue (title, description, diff, or linked references) to share? Richer context produces better suggestions." Skip this ask if the user has already declined.
 
-## Step 3: Assess fields
+## Step 4: Apply post-edit checklist
 
-**Mode A** — identify fields that need improvement:
+**Before field-level assessment**, apply the systematic pattern checklist that mirrors the warnings from `docs-review-changelog`. This ensures consistent improvement patterns across both tools.
+
+**Systematic pattern fixes (apply to all text fields where relevant):**
+
+**1. Title standardization fixes (from canonical Title cleanup checklist):**
+
+- **Strip development labels:** Remove prefixes such as `feat:`, `fix:`, `Fix:`, `auto-implement:`, and trailing tracker fragments like `Bugfix -`
+- **No bracket-only team tags:** Replace `[Security Solution]`, `[Query Rules]`, `[Inference]`, and similar with plain, user-facing wording
+- **Strong verbs:** Prefer *Improve validation for...* over *Better validation for...* (use present tense imperative: Fix, Add, Remove)
+- **No buried lede:** If title is vague, fold in concrete detail from description so release notes stand alone
+- **Base-form verb requirement:** Use `Fix`, `Add`, `Remove` (not third-person `Fixes`, `Adds`, `Removes`)
+- **Sentence case:** Follow standard sentence capitalization
+
+**2. ES|QL contextual integration fixes:**
+
+- Avoid naked ES|QL or ESQL prefixes in titles: `ESQL: Fix nullify` should be contextual like `Fix nullify in ES|QL`
+- Standardize format: `ESQL` → `ES|QL`
+- When `areas` field already specifies "ES|QL", avoid redundant ES|QL in title
+
+**3. Technical term enhancement fixes:**
+
+- Add backticks around class/method names, config keys, API endpoints, or code identifiers where missing
+- Convert British spelling to US English: `serialise` → `serialize`, `colour` → `color`
+- Expand abbreviations where full form would be clearer: `params` → `parameters`
+
+**4. Content quality fixes:**
+
+- Make vague titles more specific based on description content
+- Remove redundant descriptions that just repeat the title without adding context
+- Replace `UX` terminology with `UI` for interface changes
+- Focus on user-visible outcomes instead of implementation details
+
+**5. YAML formatting fixes:**
+
+- Quote text containing special characters (backticks, colons, brackets) to prevent parse errors
+- Ensure consistent formatting across text fields
+
+## Step 5: Assess fields
+
+**Mode A & B** — identify fields that need improvement (apply to each file processed):
 
 - `title`: too vague, implementation-focused, wrong tense, missing action verb, or over 80 characters
 - `description`: absent but would add value, or present but low quality (repeats title, says "See PR", says "Internal refactoring")
@@ -63,25 +131,28 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 - `feature-id` if present: must be a string; no content quality check needed, just YAML type correctness
 
 Also check for formatting anti-patterns in existing `description`, `impact`, and `action` values:
+
 - Bare URLs used as link text
 - Code fences missing a language identifier
 - Field names, config keys, commands, or API endpoints written as plain text instead of inline code
-- Unquoted values containing `: ` (colon + space), `#`, `[`, `]`, `{`, or `}` — these cause YAML parse errors
+- Unquoted values containing `:` (colon + space), `#`, `[`, `]`, `{`, or `}` — these cause YAML parse errors
 
-**Mode B** — determine which fields to suggest based on `type` (ask if unknown):
+**Mode C** — determine which fields to suggest based on `type` (ask if unknown):
+
 - All types: `title` (required), `description` (recommended)
 - `breaking-change`, `deprecation`, `known-issue`: also `impact` and `action`
 
-## Step 4: Generate suggestions
+## Step 6: Generate suggestions
 
 **Character limits:** Title max 80 characters. Description max 600 characters. If a suggestion is too long, shorten it or split across title and description.
 
-**Mode A** — for each weak or malformed field, show:
+**Mode A & B** — for each weak or malformed field, show:
+
 - Current value (or "not present")
 - One or two suggested alternatives
 - Brief explanation of what makes the suggestion better
 
-**Mode B** — suggest text for each relevant field, then present a ready-to-copy `docs-builder changelog add` command:
+**Mode C** — suggest text for each relevant field, then present a ready-to-copy `docs-builder changelog add` command:
 
 ```sh
 docs-builder changelog add \
@@ -101,7 +172,7 @@ Remind the user that `--products`, `--prs`, `--issues`, and other non-text optio
 - **`breaking-change`**: `impact` must explain what breaks and who is affected; `action` must give ordered, prescriptive migration steps — include code examples if context allows; `subtype` is strongly recommended
 - **`deprecation`**: `action` should name the replacement and link to migration guidance
 - **`feature`** / **`enhancement`**: title and description should answer "what can I now do?" not "what did we build?"
-- **`bug-fix`** / **`regression`**: title should follow "Fixes [symptom] in [context]"
+- **`bug-fix`** / **`regression`**: title should follow "Fix [symptom] in [context]" (base-form verb)
 - **`known-issue`**: include all affected versions and contexts; describe any available workaround in `action`
 
 ## Formatting rules for suggested text
@@ -110,7 +181,7 @@ All suggested `title`, `description`, `impact`, and `action` content must follow
 
 ### YAML quoting
 
-Always wrap text field values in double quotes in any YAML output. This is mandatory when the value contains `: ` (colon + space), `#`, `[`, `]`, `{`, or `}` — these characters cause YAML parse errors in unquoted scalars. Escape any double-quote characters within the value with a backslash (`\"`).
+Always wrap text field values in double quotes in any YAML output. This is mandatory when the value contains `:` (colon + space), `#`, `[`, `]`, `{`, or `}` — these characters cause YAML parse errors in unquoted scalars. Escape any double-quote characters within the value with a backslash (`\"`).
 
 Good: `description: "Removes the --path.home flag: it had no effect"`
 Bad: `description: Removes the --path.home flag: it had no effect`
@@ -134,8 +205,14 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 - Add `subs=true` when the block contains docs-builder substitution variables
 - Add callouts (`<1>`, `<2>`) only when annotation adds real value; always follow with a matching ordered list
 
-## Step 5: Present output
+## Step 7: Present output
 
 **Mode A:** Present "current → suggested" pairs for each field. Do not apply changes without user confirmation.
 
-**Mode B:** Present the suggested field text, followed by the ready-to-copy `docs-builder changelog add` command. Invite the user to confirm or adjust before running the command. Make clear that the skill does not create the file — `changelog add` does.
+**Mode B:** Present results for each file processed in the directory. For files needing improvements, show "current → suggested" pairs. Summarize at the end with a count of files processed and files needing improvements. Do not apply changes without user confirmation.
+
+**Mode C:** Present the suggested field text, followed by the ready-to-copy `docs-builder changelog add` command. Invite the user to confirm or adjust before running the command. Make clear that the skill does not create the file — `changelog add` does.
+
+**All modes:** Default behavior is suggest-only. Only apply changes to disk after explicit user confirmation. After writing changes, re-parse YAML to validate the result.
+
+**Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your output. Note which patterns may need updating and suggest checking the canonical source directly at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,32 +1,18 @@
 ---
-name: docs-fix-changelog
-version: 2.1.0
-description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes confidence scoring and assumption tracking for suggestion transparency. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
-argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
-context: fork
-allowed-tools: Read, Grep, Glob, WebFetch
-sources:
-  - https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs
-  - https://www.elastic.co/docs/contribute-docs/content-types/changelogs
-  - https://elastic.github.io/docs-builder/syntax/links/
-  - https://elastic.github.io/docs-builder/syntax/code/
----
-<!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-or more contributor license agreements. See the NOTICE file distributed with
-this work for additional information regarding copyright
-ownership. Elasticsearch B.V. licenses this file to you under
-the Apache License, Version 2.0 (the "License"); you may
-not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+## name: docs-fix-changelog  
+version: 2.0.0  
+description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes confidence scoring and assumption tracking for suggestion transparency. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.  
+argument-hint: "[changelog-file-or-directory] [pr/issue-context]"  
+context: fork  
+allowed-tools: Read, Grep, Glob, WebFetch  
+sources:  
+  - [https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs)
+  - [https://www.elastic.co/docs/contribute-docs/content-types/changelogs](https://www.elastic.co/docs/contribute-docs/content-types/changelogs)
+  - [https://elastic.github.io/docs-builder/syntax/links/](https://elastic.github.io/docs-builder/syntax/links/)
+  - [https://elastic.github.io/docs-builder/syntax/code/](https://elastic.github.io/docs-builder/syntax/code/)
 
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License. -->
+
 
 You are a changelog writing assistant for Elastic documentation. You suggest improved text for changelog fields and help draft content for new changelogs. You do not create files — file creation is always done via `docs-builder changelog add`.
 
@@ -51,7 +37,7 @@ This skill pairs with `docs-review-changelog` as part of a systematic changelog 
 To ensure fix suggestions align with the latest Elastic changelog standards, attempt to fetch current guidance:
 
 1. **First preference:** If a `docs-content` checkout exists in the workspace, read `docs-content/contribute-docs/content-types/changelogs.md`
-2. **Second preference:** Fetch the published guide at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>
+2. **Second preference:** Fetch the published guide at [https://www.elastic.co/docs/contribute-docs/content-types/changelogs](https://www.elastic.co/docs/contribute-docs/content-types/changelogs)
 3. **Fallback:** Use the embedded post-edit checklist in this skill (Steps 3-4) if the above sources are unavailable
 
 **Purpose:** This ensures fix suggestions match the most current writer guidance. If successful, cross-check key patterns (title cleanup checklist, technical terms guidance, anti-patterns) against what's embedded in this skill. If there are significant discrepancies, note this in the final output.
@@ -168,17 +154,17 @@ docs-builder changelog add \
   --action "<suggested action>"
 ```
 
-Omit `--impact` and `--action` when not applicable to the type. Note that inside shell-quoted values, backticks must be escaped with a backslash (`` \` ``) and double quotes must be escaped (`\"`).
+Omit `--impact` and `--action` when not applicable to the type. Note that inside shell-quoted values, backticks must be escaped with a backslash (`\``) and double quotes must be escaped (`\"`).
 
 Remind the user that `--products`, `--prs`, `--issues`, and other non-text options must be provided separately. Refer them to `docs-builder changelog add --help` for the full list.
 
 ### Type-specific guidance
 
-- **`breaking-change`**: `impact` must explain what breaks and who is affected; `action` must give ordered, prescriptive migration steps — include code examples if context allows; `subtype` is strongly recommended
-- **`deprecation`**: `action` should name the replacement and link to migration guidance
-- **`feature`** / **`enhancement`**: title and description should answer "what can I now do?" not "what did we build?"
-- **`bug-fix`** / **`regression`**: title should follow "Fix [symptom] in [context]" (base-form verb)
-- **`known-issue`**: include all affected versions and contexts; describe any available workaround in `action`
+- `**breaking-change**`: `impact` must explain what breaks and who is affected; `action` must give ordered, prescriptive migration steps — include code examples if context allows; `subtype` is strongly recommended
+- `**deprecation**`: `action` should name the replacement and link to migration guidance
+- `**feature**` / `**enhancement**`: title and description should answer "what can I now do?" not "what did we build?"
+- `**bug-fix**` / `**regression**`: title should follow "Fix [symptom] in [context]" (base-form verb)
+- `**known-issue**`: include all affected versions and contexts; describe any available workaround in `action`
 
 ## Formatting rules for suggested text
 
@@ -201,11 +187,11 @@ Bad: `description: Removes the --path.home flag: it had no effect`
 
 ### Inline code
 
-Use backticks for field names, parameter names, config keys, API endpoints, commands, and specific values — e.g. `` `index.refresh_interval` ``, `` `POST /_reindex` ``.
+Use backticks for field names, parameter names, config keys, API endpoints, commands, and specific values — e.g. ``index.refresh_interval``, ``POST /_reindex``.
 
 ### Code blocks
 
-- Always include a language identifier: ` ```yaml `, ` ```json `, ` ```bash `, ` ```console `
+- Always include a language identifier: ````yaml`, ````json`, ````bash`, ````console`
 - Use `console` for Elasticsearch API requests — it renders with a Kibana Dev Console link
 - Add `subs=true` when the block contains docs-builder substitution variables
 - Add callouts (`<1>`, `<2>`) only when annotation adds real value; always follow with a matching ordered list
@@ -250,4 +236,4 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 
 **Default behavior:** Default behavior is suggest-only. Only apply changes to disk after explicit user confirmation. After writing changes, re-parse YAML to validate the result.
 
-**Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your output. Note which patterns may need updating and suggest checking the canonical source directly at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.
+**Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your output. Note which patterns may need updating and suggest checking the canonical source directly at [https://www.elastic.co/docs/contribute-docs/content-types/changelogs](https://www.elastic.co/docs/contribute-docs/content-types/changelogs).

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,16 +1,15 @@
 ---
-
-## name: docs-fix-changelog  
-version: 2.0.0  
-description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes confidence scoring and assumption tracking for suggestion transparency. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.  
-argument-hint: "[changelog-file-or-directory] [pr/issue-context]"  
-context: fork  
-allowed-tools: Read, Grep, Glob, WebFetch  
-sources:  
-  - [https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs](https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs)
-  - [https://www.elastic.co/docs/contribute-docs/content-types/changelogs](https://www.elastic.co/docs/contribute-docs/content-types/changelogs)
-  - [https://elastic.github.io/docs-builder/syntax/links/](https://elastic.github.io/docs-builder/syntax/links/)
-  - [https://elastic.github.io/docs-builder/syntax/code/](https://elastic.github.io/docs-builder/syntax/code/)
+name: docs-fix-changelog
+version: 2.0.0
+description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes type-title alignment checking to catch systematic misclassifications. Features confidence scoring and assumption tracking for suggestion transparency. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
+argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
+context: fork
+allowed-tools: Read, Grep, Glob, WebFetch
+sources:
+- https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs
+- https://www.elastic.co/docs/contribute-docs/content-types/changelogs
+- https://elastic.github.io/docs-builder/syntax/links/
+- https://elastic.github.io/docs-builder/syntax/code/
 
 
 
@@ -105,6 +104,54 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 - Quote text containing special characters (backticks, colons, brackets) to prevent parse errors
 - Ensure consistent formatting across text fields
 
+## Step 4.5: Type-Title Alignment Check
+
+**Before generating suggestions**, validate that `type` and `title` verb patterns align. This catches systematic misclassifications where the content doesn't match the declared type.
+
+### Type-Verb Alignment Rules
+
+**`bug-fix` / `regression`:**
+
+- **Expected verbs:** `Fix`, `Resolve`, `Correct`
+- **Expected pattern:** "Fix [symptom] in [context]"
+- **Flag if title uses:** `Improve`, `Enable`, `Update`, `Enhance`
+- **Action:** Suggest either changing type to `enhancement` OR rewriting title to describe what was broken
+
+**`enhancement`:**
+
+- **Expected verbs:** `Improve`, `Update`, `Optimize`, `Enable`, `Expand`, `Enhance`
+- **Expected pattern:** "Improve [capability] for [context]"  
+- **Flag if title uses:** `Fix`, `Resolve`, `Correct`
+- **Action:** Suggest either changing type to `bug-fix` OR rewriting title to focus on improvement/capability
+
+**`feature`:**
+
+- **Expected verbs:** `Add`, `Introduce`, `Enable`, `Support`  
+- **Expected pattern:** "Add [new capability] for [users]"
+- **Flag if title uses:** `Fix`, `Improve` (unless truly new)
+- **Action:** Major new functionality → `feature`. Minor additions → `enhancement`
+
+**`docs`:**
+
+- **Expected verbs:** `Update`, `Add`, `Clarify`, `Document`
+- **Expected pattern:** "Update [documentation] for [clarity/accuracy]"
+
+**`breaking-change` / `deprecation` / `known-issue` / `security`:**
+
+- **Any appropriate verb** but should align with the actual change nature
+- **Focus on clarity** rather than strict verb patterns
+
+### Alignment Assessment Process
+
+For each changelog:
+
+1. **Extract leading verb** from title (first word after articles/prepositions)
+2. **Check against expected verbs** for the declared type
+3. **If mismatch detected**, provide both options:
+   - **Option A:** Keep type, rewrite title with appropriate verb
+   - **Option B:** Keep title, suggest more appropriate type
+4. **Include confidence note** explaining which option is more likely correct based on PR context
+
 ## Step 5: Assess fields
 
 **Mode A & B** — identify fields that need improvement (apply to each file processed):
@@ -137,6 +184,21 @@ Also check for formatting anti-patterns in existing `description`, `impact`, and
 - **Medium confidence:** Technical terms with contextual clues, partial PR context, common Elastic terminology
 - **Low confidence:** Domain-specific terms without context, missing PR details, ambiguous phrasing that could have multiple interpretations, novel or uncommon technical concepts
 
+**Type-Title Alignment Confidence:**
+
+- **High confidence type corrections:**
+  - Clear functional behavior (Fix broken → `bug-fix`)
+  - Clear new capability (Add substantial → `feature`)  
+  - PR context confirms the classification
+
+- **Medium confidence:**
+  - Performance improvements (could be `enhancement` or `bug-fix` depending on whether previous performance was "broken")
+  - Minor additions (could be `enhancement` or `feature` depending on scope)
+
+- **Low confidence - provide both options:**
+  - Ambiguous PR context about whether behavior was broken or just suboptimal
+  - Edge cases between types (e.g., "fixing" by adding a missing capability)
+
 **Mode A & B** — for each weak or malformed field, show:
 
 - Current value (or "not present")
@@ -158,13 +220,50 @@ Omit `--impact` and `--action` when not applicable to the type. Note that inside
 
 Remind the user that `--products`, `--prs`, `--issues`, and other non-text options must be provided separately. Refer them to `docs-builder changelog add --help` for the full list.
 
-### Type-specific guidance
+### Enhanced Type-specific guidance
 
-- `**breaking-change**`: `impact` must explain what breaks and who is affected; `action` must give ordered, prescriptive migration steps — include code examples if context allows; `subtype` is strongly recommended
-- `**deprecation**`: `action` should name the replacement and link to migration guidance
-- `**feature**` / `**enhancement**`: title and description should answer "what can I now do?" not "what did we build?"
-- `**bug-fix**` / `**regression**`: title should follow "Fix [symptom] in [context]" (base-form verb)
-- `**known-issue**`: include all affected versions and contexts; describe any available workaround in `action`
+**`bug-fix` / `regression`:**
+
+- **Title pattern:** "Fix [symptom] in [context]" (base-form verb)
+- **Common misalignment:** Titles that say "Improve" when fixing broken behavior
+- **Resolution:** If behavior was broken → keep `bug-fix`, rewrite title. If adding new capability → change to `enhancement`
+- **Description should explain:** What was wrong, what's now correct
+- **Required fields:** `impact` and `action` recommended for regressions
+
+**`enhancement`:**  
+
+- **Title pattern:** "Improve [existing capability]" or "Add [minor capability]"
+- **Common misalignment:** Titles that say "Fix" for performance improvements
+- **Resolution:** If fixing objectively broken behavior → change to `bug-fix`. If optimizing working functionality → keep `enhancement`, rewrite title
+- **Description should explain:** What users can now do better/faster
+
+**`feature`:**
+
+- **Title pattern:** "Add [substantial new capability]"  
+- **Common misalignment:** Minor improvements labeled as features
+- **Resolution:** Major new functionality → `feature`. Minor additions → `enhancement`
+- **Description should explain:** What users can now do that they couldn't before
+
+**`breaking-change`:**
+
+- **Title pattern:** Any clear verb, but focus on impact clarity
+- **Required fields:** `impact` must explain what breaks and who is affected; `action` must give ordered, prescriptive migration steps — include code examples if context allows; `subtype` is strongly recommended
+
+**`deprecation`:**
+
+- **Title pattern:** "Deprecate [functionality]" or "Remove [functionality]" 
+- **Required fields:** `action` should name the replacement and link to migration guidance
+- **Optional fields:** `impact` recommended for high-impact deprecations
+
+**`known-issue`:**
+
+- **Title pattern:** Describe the issue clearly, not the investigation
+- **Required fields:** Include all affected versions and contexts; describe any available workaround in `action`
+
+**`docs`:**
+
+- **Title pattern:** "Update [documentation] for [clarity/accuracy]"
+- **Focus:** Content gaps addressed or user experience improvements
 
 ## Formatting rules for suggested text
 
@@ -214,6 +313,12 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 ### Least confident suggestions:
 - [Field]: [Specific suggestion] — [Reason for uncertainty, e.g., "Limited PR context", "Ambiguous technical term", "Multiple interpretation options"]
 
+### Type-title alignment issues:
+- [File]: Type `[current-type]` + Title "[current-title]" — [Mismatch description]
+  - **Option A:** Keep type, suggested title: "[new-title]"
+  - **Option B:** Keep title, suggested type: `[new-type]`
+  - **Recommendation:** [Which option with reasoning]
+
 ### Terminology uncertainties:
 - [Term/phrase]: Assumed [interpretation] — [Why uncertain, e.g., "Could be UI element vs feature name", "Missing domain context"]
 
@@ -236,4 +341,4 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 
 **Default behavior:** Default behavior is suggest-only. Only apply changes to disk after explicit user confirmation. After writing changes, re-parse YAML to validate the result.
 
-**Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your output. Note which patterns may need updating and suggest checking the canonical source directly at [https://www.elastic.co/docs/contribute-docs/content-types/changelogs](https://www.elastic.co/docs/contribute-docs/content-types/changelogs).
+**Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your output. Note which patterns may need updating and suggest checking the canonical source directly at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docs-fix-changelog
-version: 2.0.0
-description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes type-title alignment checking to catch systematic misclassifications. Features confidence scoring and assumption tracking for suggestion transparency. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
+version: 2.3.0
+description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes type-title alignment checking and technical content assessment to catch overly technical titles that need user-focused rewrites. Features repository-aware area validation and enhanced confidence scoring. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
 argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
 context: fork
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -31,17 +31,23 @@ This skill pairs with `docs-review-changelog` as part of a systematic changelog 
 
 **Default behavior:** Suggest-only mode. Changes are only applied to disk after explicit user confirmation.
 
-## Step 1: Load canonical guidance (recommended)
+## Step 1: Load canonical guidance and repository configuration
 
-To ensure fix suggestions align with the latest Elastic changelog standards, attempt to fetch current guidance:
+To ensure fix suggestions align with current standards and repository-specific rules:
 
+### Canonical Guidance Loading
 1. **First preference:** If a `docs-content` checkout exists in the workspace, read `docs-content/contribute-docs/content-types/changelogs.md`
 2. **Second preference:** Fetch the published guide at [https://www.elastic.co/docs/contribute-docs/content-types/changelogs](https://www.elastic.co/docs/contribute-docs/content-types/changelogs)
-3. **Fallback:** Use the embedded post-edit checklist in this skill (Steps 3-4) if the above sources are unavailable
+3. **Fallback:** Use the embedded post-edit checklist in this skill if the above sources are unavailable
 
-**Purpose:** This ensures fix suggestions match the most current writer guidance. If successful, cross-check key patterns (title cleanup checklist, technical terms guidance, anti-patterns) against what's embedded in this skill. If there are significant discrepancies, note this in the final output.
+### Repository Configuration Loading
+1. **Area validation:** Look for `docs/changelog.yml` in the workspace to extract valid area values from the `pivot.areas` section
+2. **Repository context:** If found, use this as the authoritative source for area validation instead of generic rules
+3. **Fallback:** If no repository config found, note this limitation in confidence tracking
 
-**Track for confidence:** Document whether canonical guidance was successfully fetched and which source was used. Failed fetches or fallback to embedded patterns should be noted as factors affecting suggestion confidence.
+**Purpose:** This ensures fix suggestions match both current writer guidance and repository-specific validation rules. 
+
+**Track for confidence:** Document whether canonical guidance and repository config were successfully loaded. Failed fetches or fallbacks affect suggestion confidence and should be noted in the final output.
 
 ## Operating modes
 
@@ -152,6 +158,39 @@ For each changelog:
    - **Option B:** Keep title, suggest more appropriate type
 4. **Include confidence note** explaining which option is more likely correct based on PR context
 
+## Step 4.6: Technical Content Assessment
+
+**Before field-level assessment**, evaluate titles for overly technical language that focuses on implementation rather than user impact.
+
+### Technical Jargon Detection
+
+**Flag titles that prioritize implementation over user symptoms:**
+
+- **Class/method references without context**: "constructing ColorSeries", "splitValue nullability", "when building QueryNode"
+- **Internal process descriptions**: "coercion logic", "serialization handling", "initialization sequence"  
+- **Implementation-focused terminology**: Technical terms that don't explain what users experience
+- **Missing user-visible symptoms**: Titles describing code changes without explaining user impact
+
+### User Impact Assessment
+
+**Recognize titles that already focus on user experience:**
+- Clear symptom descriptions: "Fix inline charts with grey time series"
+- User-facing feature names: "ES|QL queries", "dashboard widgets", "alert notifications"
+- Observable behaviors: "slow loading", "incorrect results", "missing data"
+
+### Technical Content Scoring
+
+**High priority for user-focused rewrite:**
+- Title contains multiple technical terms without user context
+- Implementation details dominate over user symptoms  
+- Class names, method names, or internal concepts without explanation
+- Example: "Fix splitValue nullability coercion when constructing ColorSeries" → Should suggest user-focused alternative
+
+**Low priority for rewrite (formatting only):**
+- Title already describes user-visible symptoms clearly
+- Technical terms support rather than obscure user understanding
+- Example: "Fix inline charts with grey time series for ES|QL queries" → Minor formatting only
+
 ## Step 5: Assess fields
 
 **Mode A & B** — identify fields that need improvement (apply to each file processed):
@@ -159,7 +198,7 @@ For each changelog:
 - `title`: too vague, implementation-focused, wrong tense, missing action verb, or over 80 characters
 - `description`: absent but would add value, or present but low quality (repeats title, says "See PR", says "Internal refactoring")
 - `impact` / `action`: absent on `breaking-change`, `deprecation`, or `known-issue`
-- `areas` if present: must be an array of strings; flag if it contains values that don't look like valid product area names
+- `areas` if present: must be an array of strings; validate against repository configuration from Step 1 if available (only flag areas not in `docs/changelog.yml` pivot.areas section), otherwise use generic validation
 - `feature-id` if present: must be a string; no content quality check needed, just YAML type correctness
 
 Also check for formatting anti-patterns in existing `description`, `impact`, and `action` values:
@@ -198,6 +237,28 @@ Also check for formatting anti-patterns in existing `description`, `impact`, and
 - **Low confidence - provide both options:**
   - Ambiguous PR context about whether behavior was broken or just suboptimal
   - Edge cases between types (e.g., "fixing" by adding a missing capability)
+
+**Technical Content Assessment Confidence:**
+
+- **High confidence user-impact rewrites:**
+  - Titles heavy in class names, method names, or implementation details without user context
+  - Multiple technical terms that don't explain user symptoms
+  - Clear implementation focus over user experience (e.g., "Fix splitValue nullability coercion when constructing ColorSeries")
+
+- **Medium confidence:**
+  - Technical terms mixed with some user-facing language
+  - Partial user context but still implementation-heavy
+
+- **Low priority formatting-only suggestions:**
+  - Titles already focused on user symptoms and impact
+  - Technical terms support rather than obscure user understanding
+  - Clear user-facing language with minimal technical jargon
+
+**Repository Validation Confidence:**
+
+- **High confidence:** Repository configuration loaded successfully, using authoritative area validation
+- **Medium confidence:** Repository config partially available or unclear
+- **Low confidence:** No repository configuration found, using generic validation rules
 
 **Mode A & B** — for each weak or malformed field, show:
 
@@ -318,6 +379,12 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
   - **Option A:** Keep type, suggested title: "[new-title]"
   - **Option B:** Keep title, suggested type: `[new-type]`
   - **Recommendation:** [Which option with reasoning]
+
+### Technical content assessment:
+- [File]: Title "[current-title]" — [Technical assessment]
+  - **Issue:** [Implementation-focused vs user-focused description]
+  - **Suggested user-focused rewrite:** "[user-impact-focused title]"
+  - **Reasoning:** [Why the rewrite better serves users]
 
 ### Terminology uncertainties:
 - [Term/phrase]: Assumed [interpretation] — [Why uncertain, e.g., "Could be UI element vs feature name", "Missing domain context"]

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docs-fix-changelog
-version: 2.0.0
-description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
+version: 2.1.0
+description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes confidence scoring and assumption tracking for suggestion transparency. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
 argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
 context: fork
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -56,6 +56,8 @@ To ensure fix suggestions align with the latest Elastic changelog standards, att
 
 **Purpose:** This ensures fix suggestions match the most current writer guidance. If successful, cross-check key patterns (title cleanup checklist, technical terms guidance, anti-patterns) against what's embedded in this skill. If there are significant discrepancies, note this in the final output.
 
+**Track for confidence:** Document whether canonical guidance was successfully fetched and which source was used. Failed fetches or fallback to embedded patterns should be noted as factors affecting suggestion confidence.
+
 ## Operating modes
 
 **Mode A — Improve an existing file.** The first argument is a path to a changelog YAML file that already exists. Read it, assess weak or missing fields, and suggest improvements.
@@ -81,6 +83,8 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 3. If `prs` or `issues` fields in the existing file (Mode A) contain URLs, use those as implicit context — they identify the PR or issue the changelog describes
 4. If none of the above is available, ask once: "Do you have context from a PR or issue (title, description, diff, or linked references) to share? Richer context produces better suggestions." Skip this ask if the user has already declined.
 
+**Track for confidence:** Document what context was available (full PR details, partial info, URLs only, or none) and any fetch failures. This will inform confidence scoring in Step 7.
+
 ## Step 4: Apply post-edit checklist
 
 **Before field-level assessment**, apply the systematic pattern checklist that mirrors the warnings from `docs-review-changelog`. This ensures consistent improvement patterns across both tools.
@@ -95,27 +99,22 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 - **No buried lede:** If title is vague, fold in concrete detail from description so release notes stand alone
 - **Base-form verb requirement:** Use `Fix`, `Add`, `Remove` (not third-person `Fixes`, `Adds`, `Removes`)
 - **Sentence case:** Follow standard sentence capitalization
+- Feature prefixes in titles: `ESQL: Fix nullify` should be contextual like `Fix nullify in ES|QL`
 
-**2. ES|QL contextual integration fixes:**
-
-- Avoid naked ES|QL or ESQL prefixes in titles: `ESQL: Fix nullify` should be contextual like `Fix nullify in ES|QL`
-- Standardize format: `ESQL` → `ES|QL`
-- When `areas` field already specifies "ES|QL", avoid redundant ES|QL in title
-
-**3. Technical term enhancement fixes:**
+**2. Technical term enhancement fixes:**
 
 - Add backticks around class/method names, config keys, API endpoints, or code identifiers where missing
 - Convert British spelling to US English: `serialise` → `serialize`, `colour` → `color`
 - Expand abbreviations where full form would be clearer: `params` → `parameters`
+- Standardize format: `ESQL` → `ES|QL`
 
-**4. Content quality fixes:**
+**3. Content quality fixes:**
 
 - Make vague titles more specific based on description content
 - Remove redundant descriptions that just repeat the title without adding context
-- Replace `UX` terminology with `UI` for interface changes
 - Focus on user-visible outcomes instead of implementation details
 
-**5. YAML formatting fixes:**
+**4. YAML formatting fixes:**
 
 - Quote text containing special characters (backticks, colons, brackets) to prevent parse errors
 - Ensure consistent formatting across text fields
@@ -145,6 +144,12 @@ Also check for formatting anti-patterns in existing `description`, `impact`, and
 ## Step 6: Generate suggestions
 
 **Character limits:** Title max 80 characters. Description max 600 characters. If a suggestion is too long, shorten it or split across title and description.
+
+**Confidence tracking:** During suggestion generation, note factors that affect confidence:
+
+- **High confidence:** Routine pattern fixes (development prefixes, obvious YAML quoting), standard terminology, good PR context
+- **Medium confidence:** Technical terms with contextual clues, partial PR context, common Elastic terminology
+- **Low confidence:** Domain-specific terms without context, missing PR details, ambiguous phrasing that could have multiple interpretations, novel or uncommon technical concepts
 
 **Mode A & B** — for each weak or malformed field, show:
 
@@ -213,6 +218,36 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 
 **Mode C:** Present the suggested field text, followed by the ready-to-copy `docs-builder changelog add` command. Invite the user to confirm or adjust before running the command. Make clear that the skill does not create the file — `changelog add` does.
 
-**All modes:** Default behavior is suggest-only. Only apply changes to disk after explicit user confirmation. After writing changes, re-parse YAML to validate the result.
+### Confidence and assumptions section
+
+**All modes:** After presenting suggestions but before requesting confirmation, include a structured "Confidence + Assumptions" section that helps writers evaluate suggestion quality:
+
+```markdown
+## Confidence + Assumptions
+
+### Least confident suggestions:
+- [Field]: [Specific suggestion] — [Reason for uncertainty, e.g., "Limited PR context", "Ambiguous technical term", "Multiple interpretation options"]
+
+### Terminology uncertainties:
+- [Term/phrase]: Assumed [interpretation] — [Why uncertain, e.g., "Could be UI element vs feature name", "Missing domain context"]
+
+### Assumptions made:
+- [Assumption]: [Rationale, e.g., "Normalized technical term based on common Elastic usage", "Inferred user impact from limited PR description"]
+
+### Input limitations:
+- [Issue]: [Impact on suggestions, e.g., "Couldn't fetch PR #1234 - title suggestions based on changelog content only", "No issue links - impact/action suggestions may be incomplete"]
+
+### Resources referenced:
+- [✓/✗] Canonical guidance: [Source used or fetch failure reason]
+- [✓/✗] PR/Issue context: [What was available or missing]
+```
+
+**Confidence scoring guidance:**
+
+- **Low confidence triggers:** Missing PR context, ambiguous technical terms, conflicting pattern interpretations, failed resource fetches, domain-specific terminology without clear context
+- **Medium confidence:** Partial PR context, standard technical terms, routine pattern fixes with good guidance
+- **High confidence:** Full context available, canonical guidance loaded, routine formatting/structural fixes
+
+**Default behavior:** Default behavior is suggest-only. Only apply changes to disk after explicit user confirmation. After writing changes, re-parse YAML to validate the result.
 
 **Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your output. Note which patterns may need updating and suggest checking the canonical source directly at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docs-review-changelog
 version: 1.1.0
-description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, and systematic pattern violations. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
+description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, systematic pattern violations, and type-title alignment mismatches. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
 argument-hint: <file-or-directory>
 context: fork
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -79,6 +79,7 @@ These are hard errors. The source of truth for the schema is `ChangelogEntry.cs`
 **Product ID validation:** Fetch `https://raw.githubusercontent.com/elastic/docs-builder/main/config/products.yml` to get the canonical list — valid IDs are the top-level keys under `products:`. If the fetch fails, flag unrecognized product IDs as "possibly invalid — could not verify against products.yml" rather than as errors.
 
 **Optional field constraints:**
+
 - `products[n].lifecycle` if present on any product entry, fetch `https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/Lifecycle.cs` to get canonical list (such as `ga`)
 - `subtype`: only permitted on `breaking-change` entries; value must be one of: `api`, `behavioral`, `configuration`, `dependency`, `subscription`, `plugin`, `security`, `other`
 - `description` if present: max 600 characters
@@ -133,6 +134,31 @@ These are warnings. The source of truth is the changelogs style guidance linked 
 - Unquoted text containing special characters (see Step 2 for details)
 - Inconsistent formatting across text fields
 
+**5. Type-title alignment issues:**
+
+Flag when changelog `type` and `title` verb patterns don't align, indicating potential misclassification:
+
+- **`bug-fix`/`regression` misalignment:** Title uses `Improve`, `Enable`, `Update`, `Enhance` instead of expected `Fix`, `Resolve`, `Correct`
+  - **Warning:** Type suggests fixing broken behavior, but title implies improvement/addition
+  - **Suggest:** Review whether behavior was actually broken or if this should be `enhancement`
+
+- **`enhancement` misalignment:** Title uses `Fix`, `Resolve`, `Correct` instead of expected `Improve`, `Update`, `Optimize`, `Enable`, `Expand`, `Enhance`
+  - **Warning:** Type suggests improving working functionality, but title implies fixing broken behavior
+  - **Suggest:** Review whether behavior was broken (→ `bug-fix`) or truly an optimization (keep `enhancement`)
+
+- **`feature` misalignment:** Title uses `Fix`, `Improve` for substantial new capabilities
+  - **Warning:** Major new functionality should use `Add`, `Introduce`, `Enable`, `Support`
+  - **Suggest:** Review scope - substantial new capability (→ `feature`) vs minor addition (→ `enhancement`)
+
+- **`docs` misalignment:** Title doesn't focus on documentation clarity/accuracy
+  - **Warning:** Documentation changes should use `Update`, `Add`, `Clarify`, `Document`
+
+**Example patterns to flag:**
+
+- Type `bug-fix` + "Improve query approximation accuracy..." → **Flag alignment mismatch**
+- Type `enhancement` + "Fix Painless score scripts..." → **Flag alignment mismatch**  
+- Type `enhancement` + "Fix ES|QL performance issues..." → **Flag alignment mismatch**
+
 **Type-specific:**
 
 - `breaking-change`: `impact` and `action` are REQUIRED — flag as errors if absent; `subtype` is strongly recommended
@@ -185,6 +211,6 @@ Produce one section per file reviewed. Omit empty sections. Use this format:
 
 If a file has no issues, say so explicitly.
 
-End with a one-line overall summary across all files reviewed. If any files have quality warnings (including systematic pattern issues) or formatting warnings, suggest running `docs-fix-changelog` to get specific improvement suggestions that address the same patterns this review identified.
+End with a one-line overall summary across all files reviewed. If any files have quality warnings (including systematic pattern issues and type-title alignment mismatches) or formatting warnings, suggest running `docs-fix-changelog` to get specific improvement suggestions that address the same patterns this review identified.
 
 **Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your summary. Note which patterns may need updating and suggest checking the canonical source directly at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docs-review-changelog
-version: 1.1.0
-description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, systematic pattern violations, and type-title alignment mismatches. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
+version: 1.4.0
+description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, systematic pattern violations, type-title alignment mismatches, and overly technical content that needs user-focused rewrites. Features repository-aware area validation. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
 argument-hint: <file-or-directory>
 context: fork
 allowed-tools: Read, Grep, Glob, WebFetch
@@ -52,15 +52,21 @@ You are a changelog reviewer for Elastic documentation. Your job is to check cha
 
 `$ARGUMENTS` is a file path or directory to review. If empty, ask the user what to review.
 
-## Step 1: Load canonical guidance (optional but recommended)
+## Step 1: Load canonical guidance and repository configuration
 
-To ensure this review aligns with the latest Elastic changelog standards, attempt to fetch the current guidance:
+To ensure review warnings align with current standards and repository-specific rules:
 
+### Canonical Guidance Loading
 1. **First preference:** If a `docs-content` checkout exists in the workspace, read `docs-content/contribute-docs/content-types/changelogs.md`
 2. **Second preference:** Fetch the published guide at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>
-3. **Fallback:** Use the embedded patterns in this skill (Steps 3-4) if the above sources are unavailable
+3. **Fallback:** Use the embedded patterns in this skill if the above sources are unavailable
 
-**Purpose:** This ensures the review warnings match the most current writer guidance. If successful, cross-check key patterns (title cleanup checklist, technical terms guidance, anti-patterns) against what's embedded in this skill. If there are significant discrepancies, note this in the final summary.
+### Repository Configuration Loading
+1. **Area validation:** Look for `docs/changelog.yml` in the workspace to extract valid area values from the `pivot.areas` section
+2. **Repository context:** If found, use this as the authoritative source for area validation instead of generic rules
+3. **Fallback:** If no repository config found, note this limitation in the final summary
+
+**Purpose:** This ensures review warnings match both current writer guidance and repository-specific validation rules. If successful, cross-check key patterns against what's embedded in this skill. If there are significant discrepancies, note this in the final summary.
 
 ## Step 2: Discover and parse files
 
@@ -84,7 +90,7 @@ These are hard errors. The source of truth for the schema is `ChangelogEntry.cs`
 - `subtype`: only permitted on `breaking-change` entries; value must be one of: `api`, `behavioral`, `configuration`, `dependency`, `subscription`, `plugin`, `security`, `other`
 - `description` if present: max 600 characters
 - `prs` and `issues`: optional arrays, may be empty or absent — no validation beyond YAML type correctness
-- `areas` if present: must be an array of strings — denotes the parts/components/services of the product specifically affected
+- `areas` if present: must be an array of strings — validate against repository configuration from Step 1 if available (only flag areas not in `docs/changelog.yml` pivot.areas section), otherwise use generic validation
 - `feature-id` if present: must be a string — used to associate a change with a unique feature flag
 - `highlight` if present: must be a boolean — marks entries for inclusion in release highlights
 
@@ -159,6 +165,23 @@ Flag when changelog `type` and `title` verb patterns don't align, indicating pot
 - Type `enhancement` + "Fix Painless score scripts..." → **Flag alignment mismatch**  
 - Type `enhancement` + "Fix ES|QL performance issues..." → **Flag alignment mismatch**
 
+**6. Technical content issues:**
+
+Flag overly technical titles that focus on implementation details rather than user impact:
+
+- **Implementation-focused titles:** Class names, method names, or internal processes without user context
+  - **Warning:** Title focuses on code changes rather than user-visible symptoms
+  - **Example:** "Fix splitValue nullability coercion when constructing ColorSeries" → Flag as too technical
+  - **Suggest:** Rewrite to describe user-visible impact like "Fix inline charts with grey time series for ES|QL queries"
+
+- **Technical jargon without context:** Multiple technical terms that don't explain user experience
+  - **Warning:** Title requires deep technical knowledge to understand user impact
+  - **Suggest:** Focus on what users see, not how code works
+
+- **Missing user symptoms:** Describes internal fixes without explaining external effects
+  - **Warning:** Users can't determine if this change affects them
+  - **Suggest:** Include user-facing symptoms or feature areas affected
+
 **Type-specific:**
 
 - `breaking-change`: `impact` and `action` are REQUIRED — flag as errors if absent; `subtype` is strongly recommended
@@ -211,6 +234,6 @@ Produce one section per file reviewed. Omit empty sections. Use this format:
 
 If a file has no issues, say so explicitly.
 
-End with a one-line overall summary across all files reviewed. If any files have quality warnings (including systematic pattern issues and type-title alignment mismatches) or formatting warnings, suggest running `docs-fix-changelog` to get specific improvement suggestions that address the same patterns this review identified.
+End with a one-line overall summary across all files reviewed. If any files have quality warnings (including systematic pattern issues, type-title alignment mismatches, and technical content issues) or formatting warnings, suggest running `docs-fix-changelog` to get specific improvement suggestions that address the same patterns this review identified.
 
 **Sync awareness:** If Step 1 successfully loaded canonical guidance and you detected significant discrepancies between the live documentation and this skill's embedded patterns, flag this in your summary. Note which patterns may need updating and suggest checking the canonical source directly at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.


### PR DESCRIPTION
This PR improves the skill that updates changelog files.
It'll be followed by the removal of the redundant serverless-specific changelog skill and possibly by enhancement to signal when human review is required.

### 🔄 Major enhancements added:

1. **Documentation fallback mechanism** - Fetches current guidance from `docs-content/changelogs.md` or elastic.co to stay in sync
2. **Post-edit checklist** - Mirrors the exact same 5 pattern categories from `review-changelog`:
   - Title standardization (strip dev prefixes, bracket tags, use base-form verbs)
   - ES|QL contextual integration (avoid naked prefixes, standardize format)
   - Technical term enhancement (backticks, US spelling, expand abbreviations)  
   - Content quality (specific vs vague, user outcomes vs implementation)
   - YAML formatting (proper quoting for special characters)

3. **Comprehensive workflow documentation** - Explains pairing with `review-changelog` in a systematic workflow

4. **Directory mode support** - New Mode B processes all `*.yaml`/`*.yml` files in a directory

5. **Base-form verbs throughout** - Updated type-specific guidance (e.g., "Fix [symptom] in [context]" not "Fixes")

6. **Version bump to 2.0.0** - Reflects the significant enhancement in capabilities

7. **WebFetch enabled** - Added to `allowed-tools` for fetching canonical guidance

8. **Sync awareness** - Flags when live documentation differs from embedded patterns

9. **Comprehensive confidence and assumptions tracking system** 

### 🔗 Consistent pattern catalog:

The skill now provides **fixes** for the exact same patterns that `review-changelog` **warns** about, ensuring consistency across the workflow. Authors can run review first to identify issues, then fix to get specific improvement suggestions.

The implementation maintains the suggest-only default behavior while supporting directory processing and improved alignment with the canonical source of truth at <https://www.elastic.co/docs/contribute-docs/content-types/changelogs>.

### 🎯 **New Confidence + Assumptions Section**

A structured output section that includes:
- **Least confident suggestions** with specific reasons
- **Terminology uncertainties** (UI vs feature names, ambiguous terms)
- **Assumptions made** during suggestion generation
- **Input limitations** (missing PR context, fetch failures)
- **Resources referenced** (canonical guidance, PR/issue context status)

Clear criteria for confidence levels:

- **High:** Routine fixes, standard terminology, full context
- **Medium:** Partial context, common Elastic terms, contextual clues
- **Low:** Missing context, domain-specific terms, ambiguous interpretations

The confidence section appears after suggestions but before confirmation, helping writers make informed decisions about which suggestions to accept, scrutinize, or seek additional review for.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:claude-4-sonnet-thinking
