### PR TITLE
More improvements to the fix-changelog and review-changelog skills

### DIFF
--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-fix-changelog
-version: 2.4.0
+version: 2.4.1
 description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes type-title alignment checking and technical content assessment to catch overly technical titles that need user-focused rewrites. Features repository-aware area validation and enhanced confidence scoring. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
 argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
 context: fork
@@ -88,6 +88,12 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 - If PR/issue is test-only, refactor-only, or has no user-visible impact → recommend **delete file**, not a cosmetic rewrite
 - Directory mode: fetch PR context per file; skip auto-apply on low-confidence rewrites
 
+**Issue-title cross-check (when `issues` URLs are present and fetched successfully):**
+
+- Compare issue title tone to changelog title
+- If the issue title describes a **failure/symptom** (e.g. "causes recovery to fail", "cluster health became red") but the changelog title uses **preventive/restrictive** language (`Don't allow`, `Disallow`, `Prevent`), suggest a symptom-first rewrite using language from the issue title
+- Example: issue *"Adding a runtime field that shadows a sorted field causes recovery to fail"* + changelog "Don't allow runtime fields to shadow fields used in index sort" → suggest "Fix shard recovery failures when runtime fields shadow index sort fields"
+
 ## Step 4: Apply post-edit checklist
 
 Apply the systematic pattern checklist from `docs-review-changelog` (Step 4). Add fix-specific deltas below — do not re-derive the full catalog here.
@@ -148,6 +154,11 @@ Validate that `type` and `title` verb patterns align (same rules as review Step 
 - **Expected pattern:** "Fix [symptom] in [context]"
 - **Flag if title uses:** `Improve`, `Enable`, `Update`, `Enhance`
 - **Also flag:** `Default`, `Reserve`, `Ensure` without `Fix` — rewrite as **Fix [what was wrong]**
+- **Preventive/restrictive framing:** Flag titles that describe a new restriction or validation rather than the user-visible failure, especially when the title does NOT start with `Fix`, `Resolve`, or `Correct`
+  - **Leading patterns to flag:** `Don't`, `Do not`, `Disallow`, `Prevent`, `Reject`, `Block`, `Forbid`, `Prohibit`, `Restrict`, `No longer allow`
+  - **Warning:** Title explains what is now blocked, not what was broken (recovery failure, query error, cluster red, etc.)
+  - **Suggest:** Rewrite as `Fix [symptom] when [condition]` — e.g. "Don't allow runtime fields to shadow index sort fields" → "Fix shard recovery failures when runtime fields shadow index sort fields"
+  - **Type note:** If the change only adds validation with no prior user-visible failure, consider `enhancement` instead of `bug-fix`
 - **Action:** Suggest either changing type to `enhancement` OR rewriting title to describe what was broken
 
 **`enhancement`:**
@@ -195,6 +206,7 @@ Evaluate titles for implementation-focused language. Rewrite using `[Fix|Improve
 - **Internal process descriptions**: "coercion logic", "serialization handling", "initialization sequence"  
 - **Implementation-focused terminology**: Technical terms that don't explain what users experience
 - **Missing user-visible symptoms**: Titles describing code changes without explaining user impact
+- **Preventive vs corrective:** On `bug-fix`/`regression`, if the title lacks symptom words (fail, error, crash, leak, hang, timeout, incorrect, missing, red, unallocated) and instead uses restriction words (allow, disallow, prevent, reject, validate, block), flag as likely preventive framing — soft heuristic for human review, not auto-fail
 
 ### User Impact Assessment
 
@@ -321,8 +333,8 @@ Remind the user that `--products`, `--prs`, `--issues`, and other non-text optio
 **`bug-fix` / `regression`:**
 
 - **Title pattern:** "Fix [symptom] in [context]" (base-form verb)
-- **Common misalignment:** Titles that say "Improve" when fixing broken behavior
-- **Resolution:** If behavior was broken → keep `bug-fix`, rewrite title. If adding new capability → change to `enhancement`
+- **Common misalignment:** Titles that say "Improve" when fixing broken behavior; preventive framing (`Don't allow`, `Disallow`, `Prevent`) instead of symptom-first `Fix [symptom] when [condition]`
+- **Resolution:** If behavior was broken → keep `bug-fix`, rewrite title. If adding new capability → change to `enhancement`. Use issue title language when available (Step 3 cross-check)
 - **Description should explain:** What was wrong, what's now correct
 - **Required fields:** `impact` and `action` recommended for regressions
 

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-fix-changelog
-version: 2.3.1
+version: 2.4.0
 description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes type-title alignment checking and technical content assessment to catch overly technical titles that need user-focused rewrites. Features repository-aware area validation and enhanced confidence scoring. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
 argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
 context: fork
@@ -82,15 +82,20 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 
 **Track for confidence:** Document what context was available (full PR details, partial info, URLs only, or none) and any fetch failures. This will inform confidence scoring in Step 7.
 
+**PR fetch and eligibility:**
+
+- When `prs` or `issues` URLs exist in the file, fetch them before suggesting — required, not optional
+- If PR/issue is test-only, refactor-only, or has no user-visible impact → recommend **delete file**, not a cosmetic rewrite
+- Directory mode: fetch PR context per file; skip auto-apply on low-confidence rewrites
+
 ## Step 4: Apply post-edit checklist
 
-**Before field-level assessment**, apply the systematic pattern checklist that mirrors the warnings from `docs-review-changelog`. This ensures consistent improvement patterns across both tools.
-
-**Systematic pattern fixes (apply to all text fields where relevant):**
+Apply the systematic pattern checklist from `docs-review-changelog` (Step 4). Add fix-specific deltas below — do not re-derive the full catalog here.
 
 **1. Title standardization fixes (from canonical Title cleanup checklist):**
 
-- **Strip development labels:** Remove prefixes such as `feat:`, `fix:`, `Fix:`, `auto-implement:`, and trailing tracker fragments like `Bugfix -`
+- **Strip development labels:** Remove prefixes such as `feat:`, `fix:`, `Fix:`, `auto-implement:`, and trailing tracker fragments like `Bugfix -` — also strip `ES|QL|DS`, `Aggs:`, `GPU codec:`, `DiskBBQ -` (see review skill Step 4.1)
+- **Replace slash lists:** Convert `/` enumerations to Oxford comma lists in titles (e.g., `foo/bar/baz` → `foo, bar, and baz`)
 - **No bracket-only team tags:** Replace `[Security Solution]`, `[Query Rules]`, `[Inference]`, and similar with plain, user-facing wording
 - **Strong verbs:** Prefer *Improve validation for...* over *Better validation for...* (use present tense imperative: Fix, Add, Remove)
 - **No buried lede:** If title is vague, fold in concrete detail from description so release notes stand alone
@@ -100,11 +105,19 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 
 **2. Technical term enhancement fixes:**
 
+| Acronym | Action |
+|---|---|
+| `NPE` | Expand to NullPointerException |
+| `UOE` | Expand to UnsupportedOperationException |
+| `PIT` | Expand to point-in-time |
+| `GPU`, `API`, `HTTP`, `OTLP` | Keep uppercase |
+| `ESQL` | Standardize to `ES|QL` |
+| `OSQ` and other domain acronyms | Expand only with PR confirmation |
+
 - Add backticks around class/method names, config keys, API endpoints, or code identifiers where missing
 - Convert British spelling to US English: `serialise` → `serialize`, `colour` → `color`
 - Expand abbreviations where full form would be clearer: `params` → `parameters`
-- **Acronym expansion caution:** When expanding abbreviations/acronyms (2-4 uppercase letters), flag as uncertain unless clearly defined in PR context or covered in `docs-flag-jargon-skill` patterns
-- **Elastic acronym validation:** For common Elastic acronyms, cross-reference with patterns from `docs-flag-jargon-skill` if uncertain about expansion
+- **Acronym expansion:** Follow the table above; flag domain acronyms as uncertain without PR context
 - Standardize format: `ESQL` → `ES|QL`
 
 **3. Content quality fixes:**
@@ -127,15 +140,14 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 
 ## Step 4.5: Type-Title Alignment Check
 
-**Before generating suggestions**, validate that `type` and `title` verb patterns align. This catches systematic misclassifications where the content doesn't match the declared type.
-
-### Type-Verb Alignment Rules
+Validate that `type` and `title` verb patterns align (same rules as review Step 4.5). When mismatch detected, provide both options: keep type and rewrite title, or keep title and suggest type change.
 
 **`bug-fix` / `regression`:**
 
 - **Expected verbs:** `Fix`, `Resolve`, `Correct`
 - **Expected pattern:** "Fix [symptom] in [context]"
 - **Flag if title uses:** `Improve`, `Enable`, `Update`, `Enhance`
+- **Also flag:** `Default`, `Reserve`, `Ensure` without `Fix` — rewrite as **Fix [what was wrong]**
 - **Action:** Suggest either changing type to `enhancement` OR rewriting title to describe what was broken
 
 **`enhancement`:**
@@ -175,9 +187,7 @@ For each changelog:
 
 ## Step 4.6: Technical Content Assessment
 
-**Before field-level assessment**, evaluate titles for overly technical language that focuses on implementation rather than user impact.
-
-### Technical Jargon Detection
+Evaluate titles for implementation-focused language. Rewrite using `[Fix|Improve|Add] [user-visible outcome] [in context]` — e.g., "Fix splitValue nullability coercion when constructing ColorSeries" → "Fix inline charts with grey time series for ES|QL queries".
 
 **Flag titles that prioritize implementation over user symptoms:**
 
@@ -199,12 +209,10 @@ For each changelog:
 - Title contains multiple technical terms without user context
 - Implementation details dominate over user symptoms  
 - Class names, method names, or internal concepts without explanation
-- Example: "Fix splitValue nullability coercion when constructing ColorSeries" → Should suggest user-focused alternative
 
 **Low priority for rewrite (formatting only):**
 - Title already describes user-visible symptoms clearly
 - Technical terms support rather than obscure user understanding
-- Example: "Fix inline charts with grey time series for ES|QL queries" → Minor formatting only
 
 ## Step 5: Assess fields
 
@@ -230,7 +238,7 @@ Also check for formatting anti-patterns in existing `description`, `impact`, and
 
 ## Step 6: Generate suggestions
 
-**Character limits:** Target 80/600 characters; prefer clarity over trimming; split excess detail into `description` rather than shortening accurate titles.
+**Character limits:** Target 80/600 characters; prefer clarity over trimming; split excess detail into `description` rather than shortening accurate titles. Suggest optional `description` when technical detail is stripped from the title.
 
 **Confidence tracking:** During suggestion generation, note factors that affect confidence:
 

--- a/skills/changelogs/fix-changelog/evals/evals.json
+++ b/skills/changelogs/fix-changelog/evals/evals.json
@@ -147,6 +147,29 @@
         "Keeps GPU, API, HTTP, OTLP uppercase per acronym table",
         "High confidence for function identifier formatting"
       ]
+    },
+    {
+      "id": 14,
+      "prompt": "Fix changelog: type bug-fix, title 'Don't allow runtime fields to shadow fields used in index sort'. Issue #149500 title: 'Adding a runtime field that shadows a sorted field causes recovery to fail'.",
+      "expected_output": "Symptom-first rewrite using issue title language; flags preventive framing",
+      "expectations": [
+        "Suggests rewrite like 'Fix shard recovery failures when runtime fields shadow index sort fields'",
+        "Uses issue-title cross-check: recovery failure from issue, not restriction from changelog",
+        "Flags preventive/restrictive framing on bug-fix type",
+        "Keeps type bug-fix when issue confirms prior user-visible failure",
+        "Documents issue context in confidence section"
+      ]
+    },
+    {
+      "id": 15,
+      "prompt": "Fix changelog: type bug-fix, title 'Prevent invalid mappings from being applied during index creation'",
+      "expected_output": "Flags preventive framing; suggests Fix [symptom] when [condition] or type change if no prior failure",
+      "expectations": [
+        "Flags Prevent as preventive/restrictive framing without Fix/Resolve/Correct",
+        "Suggests symptom-first rewrite or enhancement type if no prior user-visible failure",
+        "Includes type-title alignment in confidence section",
+        "Does not false-positive on titles already starting with Fix and including symptoms"
+      ]
     }
   ]
 }

--- a/skills/changelogs/fix-changelog/evals/evals.json
+++ b/skills/changelogs/fix-changelog/evals/evals.json
@@ -81,6 +81,72 @@
         "Documents ambiguity in feature prefix confidence section",
         "Uses integration template: '[Feature]: Enable [capability]' → 'Enable [capability] for [feature]'"
       ]
+    },
+    {
+      "id": 8,
+      "prompt": "Fix changelog title: 'Fix routing/serialization/coercion errors in ES|QL queries'",
+      "expected_output": "Replace slash-separated enumeration with Oxford comma list in suggested title",
+      "expectations": [
+        "Suggests title with Oxford comma list instead of routing/serialization/coercion",
+        "Preserves user-visible meaning (ES|QL query errors)",
+        "Shows high confidence for structural slash-list fix",
+        "Does not over-trim accurate technical context in description if needed"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Fix changelog title: 'Repro and fix UOE in PIT search after upgrade'. PR confirms UnsupportedOperationException on point-in-time searches.",
+      "expected_output": "Strip dev phrasing, expand UOE and PIT per acronym table, user-focused rewrite",
+      "expectations": [
+        "Strips 'Repro and fix' dev language",
+        "Expands UOE to UnsupportedOperationException and PIT to point-in-time per acronym table",
+        "Rewrites to user-visible symptom, not class/method passthrough",
+        "Documents PR-confirmed expansions in confidence section"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Fix changelog: type bug-fix, title 'Default timeout for cross-cluster search requests'",
+      "expected_output": "Rewrite as Fix [what was wrong] for bug-fix type-title alignment",
+      "expectations": [
+        "Flags Default without Fix as bug-fix misalignment",
+        "Suggests rewrite like 'Fix incorrect default timeout for cross-cluster search requests'",
+        "Keeps type bug-fix when PR confirms broken behavior",
+        "Includes type-title alignment in confidence section"
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "Fix changelog: title 'Fix splitValue nullability coercion when constructing ColorSeries'. PR describes grey inline charts for ES|QL time series.",
+      "expected_output": "User-symptom rewrite using Fix [outcome] [in context] template; optional description for stripped detail",
+      "expectations": [
+        "Suggests user-focused title e.g. grey inline charts for ES|QL queries",
+        "Uses [Fix|Improve|Add] [user-visible outcome] [in context] template",
+        "Suggests optional description when technical detail moved out of title",
+        "High confidence when PR context confirms user symptom"
+      ]
+    },
+    {
+      "id": 12,
+      "prompt": "Fix changelog file with prs: [https://github.com/elastic/elasticsearch/pull/12345]. Fetched PR is test-only Mockito refactor, no user-visible change.",
+      "expected_output": "Recommend delete file, not cosmetic rewrite; required PR fetch before suggesting",
+      "expectations": [
+        "Fetches PR from prs URL before suggesting (required)",
+        "Recommends deleting changelog file for test-only/refactor-only/no user impact",
+        "Does not suggest cosmetic title polish when entry should be removed",
+        "Notes low confidence skip for directory mode auto-apply when applicable"
+      ]
+    },
+    {
+      "id": 13,
+      "prompt": "Fix changelog: areas: [ES|QL], title 'Add JSON_EXTRACT and UNION_BY_NAME functions for nested data'",
+      "expected_output": "Backtick ES|QL function tokens; standardize ES|QL product form",
+      "expectations": [
+        "Adds backticks around JSON_EXTRACT and UNION_BY_NAME when areas includes ES|QL",
+        "Uses ES|QL not ESQL in suggested text",
+        "Keeps GPU, API, HTTP, OTLP uppercase per acronym table",
+        "High confidence for function identifier formatting"
+      ]
     }
   ]
 }

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-review-changelog
-version: 1.5.0
+version: 1.5.1
 description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, systematic pattern violations, type-title alignment mismatches, and overly technical content that needs user-focused rewrites. Features repository-aware area validation. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
 argument-hint: <file-or-directory>
 context: fork
@@ -110,6 +110,8 @@ These are warnings. The source of truth is the changelogs style guidance linked 
 
 - Title starts with base-form action verb (`Add`, `Fix`, `Improve`, `Remove`, `Update`…) — not third-person forms (`Adds`, `Fixes`)
 - Flag: title does not start with an approved base-form verb for the declared `type` (noun-phrase titles)
+- Flag titles starting with negative imperatives: `Don't`, `Do not` — these are not approved leading verbs for any type
+- Flag noun-phrase or gerund-led titles: `Ability to`, `Adding`, `Changing`, `Using`, `Shutdown`
 - Flag: slash-separated enumerations in titles (`foo/bar/baz`)
 - Title is specific, not vague ("Bug fixes" or "Performance improvements" are too vague)
 - Title avoids bare internal references ("PR #123", "bug #456") — these don't help users
@@ -161,6 +163,11 @@ Flag when changelog `type` and `title` verb patterns don't align, indicating pot
   - **Warning:** Type suggests fixing broken behavior, but title implies improvement/addition
   - **Suggest:** Review whether behavior was actually broken or if this should be `enhancement`
 - **`bug-fix`/`regression` enhancement verbs:** On `bug-fix`, flag titles starting with `Default`, `Reserve`, `Ensure`, or `Close` without `Fix`
+- **`bug-fix`/`regression` preventive/restrictive framing:** Flag titles that describe a new restriction or validation rather than the user-visible failure, especially when the title does NOT start with `Fix`, `Resolve`, or `Correct`
+  - **Leading patterns to flag:** `Don't`, `Do not`, `Disallow`, `Prevent`, `Reject`, `Block`, `Forbid`, `Prohibit`, `Restrict`, `No longer allow`
+  - **Warning:** Title explains what is now blocked, not what was broken (recovery failure, query error, cluster red, etc.)
+  - **Suggest:** Rewrite as `Fix [symptom] when [condition]` — e.g. "Don't allow runtime fields to shadow index sort fields" → "Fix shard recovery failures when runtime fields shadow index sort fields"
+  - **Type note:** If the change only adds validation with no prior user-visible failure, consider `enhancement` instead of `bug-fix`
 
 - **`enhancement` misalignment:** Title uses `Fix`, `Resolve`, `Correct` instead of expected `Improve`, `Update`, `Optimize`, `Enable`, `Expand`, `Enhance`
   - **Warning:** Type suggests improving working functionality, but title implies fixing broken behavior
@@ -176,6 +183,7 @@ Flag when changelog `type` and `title` verb patterns don't align, indicating pot
 **Example patterns to flag:**
 
 - Type `bug-fix` + "Improve query approximation accuracy..." → **Flag alignment mismatch**
+- Type `bug-fix` + "Don't allow runtime fields to shadow fields used in index sort" → **Flag preventive framing + verb mismatch**
 - Type `enhancement` + "Fix Painless score scripts..." → **Flag alignment mismatch**  
 - Type `enhancement` + "Fix ES|QL performance issues..." → **Flag alignment mismatch**
 
@@ -195,6 +203,7 @@ Flag overly technical titles that focus on implementation details rather than us
 - **Missing user symptoms:** Describes internal fixes without explaining external effects
   - **Warning:** Users can't determine if this change affects them
   - **Suggest:** Include user-facing symptoms or feature areas affected
+- **Preventive vs corrective:** On `bug-fix`/`regression`, if the title lacks symptom words (fail, error, crash, leak, hang, timeout, incorrect, missing, red, unallocated) and instead uses restriction words (allow, disallow, prevent, reject, validate, block), flag as likely preventive framing — soft heuristic for human review, not auto-fail
 - **Dev/test language:** Flag `Repro and fix` phrasing and PR-title passthrough with class/method names
 - **Unexpanded dev acronyms:** Flag `NPE`, `UOE` — expand per `docs-fix-changelog` acronym table
 - **ES|QL function tokens:** When `areas` includes `ES|QL`, flag unbackticked function names (`UNION_BY_NAME`, `JSON_EXTRACT`, etc.)

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-review-changelog
-version: 1.4.1
+version: 1.5.0
 description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, systematic pattern violations, type-title alignment mismatches, and overly technical content that needs user-focused rewrites. Features repository-aware area validation. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
 argument-hint: <file-or-directory>
 context: fork
@@ -109,6 +109,8 @@ These are warnings. The source of truth is the changelogs style guidance linked 
 **All types:**
 
 - Title starts with base-form action verb (`Add`, `Fix`, `Improve`, `Remove`, `Update`…) — not third-person forms (`Adds`, `Fixes`)
+- Flag: title does not start with an approved base-form verb for the declared `type` (noun-phrase titles)
+- Flag: slash-separated enumerations in titles (`foo/bar/baz`)
 - Title is specific, not vague ("Bug fixes" or "Performance improvements" are too vague)
 - Title avoids bare internal references ("PR #123", "bug #456") — these don't help users
 - Title and description avoid implementation-focused language (describe user impact, not code changes)
@@ -118,7 +120,7 @@ These are warnings. The source of truth is the changelogs style guidance linked 
 
 **1. Title standardization issues (from canonical Title cleanup checklist):**
 
-- **Strip development labels:** Remove prefixes such as `feat:`, `fix:`, `Fix:`, `auto-implement:`, and trailing tracker fragments like `Bugfix -`
+- **Strip development labels:** Remove prefixes such as `feat:`, `fix:`, `Fix:`, `auto-implement:`, `ES|QL|DS`, `Aggs:`, `GPU codec:`, `DiskBBQ -`, and trailing tracker fragments like `Bugfix -`
 - **No bracket-only team tags:** Replace `[Security Solution]`, `[Query Rules]`, `[Inference]`, and similar with plain, user-facing wording
 - **Strong verbs:** Prefer *Improve validation for...* over *Better validation for...* (use present tense imperative: Fix, Add, Remove)
 - **No buried lede:** If title is vague, fold in concrete detail from description so release notes stand alone
@@ -158,6 +160,7 @@ Flag when changelog `type` and `title` verb patterns don't align, indicating pot
 - **`bug-fix`/`regression` misalignment:** Title uses `Improve`, `Enable`, `Update`, `Enhance` instead of expected `Fix`, `Resolve`, `Correct`
   - **Warning:** Type suggests fixing broken behavior, but title implies improvement/addition
   - **Suggest:** Review whether behavior was actually broken or if this should be `enhancement`
+- **`bug-fix`/`regression` enhancement verbs:** On `bug-fix`, flag titles starting with `Default`, `Reserve`, `Ensure`, or `Close` without `Fix`
 
 - **`enhancement` misalignment:** Title uses `Fix`, `Resolve`, `Correct` instead of expected `Improve`, `Update`, `Optimize`, `Enable`, `Expand`, `Enhance`
   - **Warning:** Type suggests improving working functionality, but title implies fixing broken behavior
@@ -192,6 +195,15 @@ Flag overly technical titles that focus on implementation details rather than us
 - **Missing user symptoms:** Describes internal fixes without explaining external effects
   - **Warning:** Users can't determine if this change affects them
   - **Suggest:** Include user-facing symptoms or feature areas affected
+- **Dev/test language:** Flag `Repro and fix` phrasing and PR-title passthrough with class/method names
+- **Unexpanded dev acronyms:** Flag `NPE`, `UOE` — expand per `docs-fix-changelog` acronym table
+- **ES|QL function tokens:** When `areas` includes `ES|QL`, flag unbackticked function names (`UNION_BY_NAME`, `JSON_EXTRACT`, etc.)
+
+**Eligibility (report only — never delete files):**
+
+- Recommend removal when linked PR/issue is test-only, refactor-only, or internal plumbing with no user-visible change
+- Without PR context: flag title/description mentioning test-only work or internal refactor
+- Report under `### Recommend removal`; do not modify or delete files
 
 **Type-specific:**
 
@@ -241,6 +253,9 @@ Produce one section per file reviewed. Omit empty sections. Use this format:
 
 ### Formatting warnings
 - `field`: description of the problem
+
+### Recommend removal
+- Optional; include only when eligibility checks fire — reason and PR/issue reference if available
 ```
 
 If a file has no issues, say so explicitly.

--- a/skills/changelogs/review-changelog/evals/evals.json
+++ b/skills/changelogs/review-changelog/evals/evals.json
@@ -132,6 +132,29 @@
         "States review never deletes files — report only",
         "Heuristic fires on test-only/internal refactor signals from PR or description"
       ]
+    },
+    {
+      "id": 13,
+      "prompt": "Review changelog: type bug-fix, title 'Don't allow runtime fields to shadow fields used in index sort'",
+      "expected_output": "Flags preventive/restrictive framing and negative imperative verb mismatch on bug-fix",
+      "expectations": [
+        "Flags Don't as negative imperative — not an approved leading verb",
+        "Flags preventive/restrictive framing: describes restriction not user-visible failure",
+        "Suggests symptom-first rewrite pattern Fix [symptom] when [condition]",
+        "Notes type-title alignment mismatch for bug-fix without Fix/Resolve/Correct",
+        "Reports under quality warnings, not schema errors"
+      ]
+    },
+    {
+      "id": 14,
+      "prompt": "Review changelog: type bug-fix, title 'Ability to configure custom timeouts for cross-cluster search'",
+      "expected_output": "Flags noun-phrase title missing approved base-form leading verb",
+      "expectations": [
+        "Flags 'Ability to' as noun-phrase or gerund-led title pattern",
+        "Notes title does not start with approved base-form verb for bug-fix (Fix, Resolve, Correct)",
+        "Categorizes under quality warnings",
+        "Does not auto-fix — report only"
+      ]
     }
   ]
 }

--- a/skills/changelogs/review-changelog/evals/evals.json
+++ b/skills/changelogs/review-changelog/evals/evals.json
@@ -66,6 +66,72 @@
         "Notes title standardization issues in systematic order",
         "Demonstrates comprehensive title pattern checking"
       ]
+    },
+    {
+      "id": 7,
+      "prompt": "Review changelog: type enhancement, title 'Dashboard widget loading improvements for Discover'",
+      "expected_output": "Flags noun-phrase title missing approved base-form leading verb for declared type",
+      "expectations": [
+        "Flags title does not start with approved base-form verb (noun phrase)",
+        "Notes expected verbs for enhancement type (Improve, Update, Enable, etc.)",
+        "Categorizes under quality warnings, not schema errors",
+        "Does not auto-fix — report only"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Review changelog: title 'Fix routing/serialization/coercion errors in ES|QL'",
+      "expected_output": "Flags slash-separated enumeration in title",
+      "expectations": [
+        "Flags slash-separated list foo/bar/baz pattern in title",
+        "Suggests Oxford comma list or clearer phrasing via fix-changelog",
+        "Does not treat slashes in code paths or URLs as the same issue if clearly technical",
+        "Reports under quality warnings"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Review changelog: title 'Aggs: Fix incorrect bucket counts in date histogram'",
+      "expected_output": "Flags development or feature prefix Aggs: as title standardization issue",
+      "expectations": [
+        "Flags 'Aggs:' prefix in strip-development-labels / prefix patterns",
+        "Also checks ES|QL|DS, GPU codec:, DiskBBQ - style prefixes when present",
+        "Does not confuse legitimate technical colons (Authorization: Bearer) with feature prefixes",
+        "Notes contextual integration needed"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Review changelog: type bug-fix, title 'Repro and fix NPE when building QueryNode', description: 'See PR'",
+      "expected_output": "Flags dev/test language, unexpanded NPE, and internal implementation title",
+      "expectations": [
+        "Flags 'Repro and fix' dev/test phrasing",
+        "Flags unexpanded dev acronym NPE (reference fix-changelog acronym table)",
+        "Flags implementation-focused title (QueryNode, class/method passthrough)",
+        "Flags low-value description 'See PR' when present"
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "Review changelog: type bug-fix, title 'Default search timeout when cluster is under load'",
+      "expected_output": "Flags bug-fix type with enhancement-style verb Default without Fix",
+      "expectations": [
+        "Flags type-title misalignment: Default/Reserve/Ensure/Close without Fix on bug-fix",
+        "Distinguishes from legitimate enhancement titles with Improve/Update",
+        "Suggests reviewing whether title should start with Fix",
+        "Reports under type-title alignment or quality warnings"
+      ]
+    },
+    {
+      "id": 12,
+      "prompt": "Review changelog with areas: [ES|QL], title 'Add UNION_BY_NAME support for nested queries'. PR linked is test-only refactor with no user-visible change.",
+      "expected_output": "Flags unbackticked ES|QL function token and recommends removal for no user impact",
+      "expectations": [
+        "When areas includes ES|QL, flags unbackticked function token UNION_BY_NAME",
+        "Includes Recommend removal subsection when PR is test-only/refactor-only",
+        "States review never deletes files — report only",
+        "Heuristic fires on test-only/internal refactor signals from PR or description"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR includes more updates the review-changelog and fix-changelog skills related to more rounds of Elasticsearch and Kibana serverless releases.