### PR TITLE
applies-to-tagging: require no blank line between heading and section-level block

### DIFF
--- a/skills/authoring/applies-to-tagging/SKILL.md
+++ b/skills/authoring/applies-to-tagging/SKILL.md
@@ -66,8 +66,9 @@ applies_to:
 ---
 ```
 
-**Section-level** (after a heading — applies to everything between that heading and the next heading of the same or higher level):
+**Section-level** (after a heading — applies to everything between that heading and the next heading of the same or higher level). Place the block on the line directly below the heading, with **no blank line** between the heading and the block:
 ````markdown
+## Section heading
 ```{applies_to}
 stack: ga 9.1+
 serverless: unavailable
@@ -184,7 +185,7 @@ When validating, check for these errors:
 7. **Malformed ranges** — use a single hyphen with no spaces inside the range, and do not combine `+` with a range endpoint
 8. **No overlapping ranges** — `ga 9.2+, beta 9.0-9.2` is invalid because 9.2 overlaps
 9. **Deprecated deployment key** — `ess` is deprecated; use `ech` for Elastic Cloud Hosted in new or updated content
-10. **Heading annotations** — section-level only, never use inline annotations with headings
+10. **Heading annotations** — section-level only, never use inline annotations with headings; the block goes on the line directly below the heading, with no blank line between them
 11. **Version numbers in prose** — never write versions in text next to applies_to badges
 
 ## Guidelines for tagging


### PR DESCRIPTION
## Summary

- Strengthen the `applies-to-tagging` skill's section-level guidance to state that the `applies_to` block must sit on the line **directly below the heading, with no blank line in between**.
- Update the section-level example to show the heading above the block (previously the example omitted the heading, so the spacing rule wasn't demonstrable).
- Add the spacing requirement to the heading-annotations validation rule.

## Why

Came up in a real docs PR review: a blank line had been left between section headings and their `applies_to` blocks. The skill described section-level placement but never specified the no-blank-line rule, and the example didn't show the heading, so there was nothing to anchor the rule to.


Made with [Cursor](https://cursor.com)