### PR TITLE
create-skill: quote argument-hint to keep it a YAML string

### DIFF
--- a/.claude/skills/create-skill/SKILL.md
+++ b/.claude/skills/create-skill/SKILL.md
@@ -3,7 +3,7 @@ name: create-skill
 version: 1.0.0
 description: Interactively create a new Claude Code skill and add it to the elastic-docs-skills catalog. Use when the user wants to generate a new skill, scaffold a slash command, or build automation for docs tasks.
 disable-model-invocation: true
-argument-hint: [skill-name (optional)]
+argument-hint: "[skill-name (optional)]"
 allowed-tools: Read, Write, Bash(mkdir *), Bash(ls *), Bash(git *), Bash(gh *), Glob, Grep, AskUserQuestion
 ---
 <!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one


### PR DESCRIPTION
## Summary

`.claude/skills/create-skill/SKILL.md` has:

```yaml
argument-hint: [skill-name (optional)]
```

Copilot CLI 1.0.65 tightened SKILL.md frontmatter parsing and now requires `argument-hint` to be a **string**. YAML parses the unquoted `[...]` value as a flow sequence (a list), which breaks skill loading under the new release.

Fix: wrap the value in double quotes so it parses as a plain string.

```diff
-argument-hint: [skill-name (optional)]
+argument-hint: "[skill-name (optional)]"
```

This is also latent on Claude Code, tracked in [anthropics/claude-code#22161](https://github.com/anthropics/claude-code/issues/22161).

## YAML rule

Any `argument-hint` value whose first non-whitespace character is `[` must be quoted, otherwise YAML treats it as a sequence. Two safe forms:

- `argument-hint: "[foo]"` — string containing brackets
- `argument-hint: "foo"` — plain string (drop the brackets entirely)

## Scope of changes in this repo

I scanned every `SKILL.md` in the tree. Only one file has the bug:

- `.claude/skills/create-skill/SKILL.md`

All other `SKILL.md` files use angle-bracket placeholders (`<file-or-directory>`, etc.) or already-quoted strings, which are safe.

Note: `README.md` and `CONTRIBUTING.md` show `argument-hint: [args]` and `argument-hint: <args>` as *documentation examples* of the frontmatter schema, not as live frontmatter that gets parsed. I left the docs alone in this PR to keep the change minimal, but happy to follow up with a docs tweak that recommends the quoted form if you'd like.

## Test plan

- [x] Confirmed `python3 -c "import yaml; yaml.safe_load(open('.claude/skills/create-skill/SKILL.md').read().split('---')[1])"` returns `argument-hint` as a Python `str`, not a `list`, after the change.
- [x] Diff is a single-character-scope change (adds two `\"` quotes) — no behavior change beyond frontmatter typing.
- [x] CI (`validate-skills.yml`) passes on the PR.
