### PR TITLE
Add docs-draft-workflow-docs skill

### DIFF
--- a/skills/project/docs-draft-workflow-docs/SKILL.md
+++ b/skills/project/docs-draft-workflow-docs/SKILL.md
@@ -1,0 +1,528 @@
+---
+name: docs-draft-workflow-docs
+version: 1.1.7
+description: Draft or update Elastic Workflows documentation pages in explore-analyze/workflows/ — step references, use cases, how-tos, concepts, and overviews. Use when writing Workflows docs, documenting a step type, turning workflow YAML into documentation, drafting from a doc issue in docs-content or docs-content-internal, or creating a new page under the Workflows docset.
+argument-hint: <doc-issue-url-or-page-idea-or-file-path>
+disable-model-invocation: true
+context: fork
+allowed-tools: Read, Grep, Glob, Edit, Write, CallMcpTool, WebFetch, Bash(gh *), AskUserQuestion
+sources:
+  - https://www.elastic.co/docs/explore-analyze/workflows
+  - https://www.elastic.co/docs/explore-analyze/workflows/reference/cheat-sheet
+  - https://www.elastic.co/docs/explore-analyze/workflows/reference/step-types
+  - https://www.elastic.co/docs/explore-analyze/workflows/authoring-techniques/anatomy
+  - https://www.elastic.co/docs/contribute-docs/content-types/how-tos
+  - https://www.elastic.co/docs/contribute-docs/content-types/overviews
+  - https://github.com/elastic/kibana/tree/main/src/platform/packages/shared/kbn-workflows/spec
+  - https://github.com/elastic/kibana/tree/main/src/platform/plugins/shared/workflows_extensions/dev_docs
+---
+<!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+or more contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright
+ownership. Elasticsearch B.V. licenses this file to you under
+the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. -->
+
+You are a Workflows documentation author for Elastic. Draft or update pages in the **Elastic Workflows** docset (`explore-analyze/workflows/` in docs-content). Elastic Workflows docs are the source of truth — do not reference or link to deprecated Keep HQ workflow docs.
+
+## Scope check (required first)
+
+Before intake, research, or drafting, confirm the request belongs in this skill.
+
+**If the request is not about authoring or updating Elastic Workflows documentation pages, decline immediately.** Explain this skill's scope and stop. Do not run Steps 0–6 for out-of-scope work.
+
+**In scope** — pages under `explore-analyze/workflows/` in docs-content:
+
+- Step references (e.g., `workflows/steps/cases.md` for `cases.*` workflow steps)
+- Use cases, how-tos, concepts, overviews, reference pages, and migration guides in the Workflows docset
+- Doc issues whose deliverable is a new or updated Workflows docset page
+
+**Out of scope** — decline rather than reframe:
+
+- General product documentation outside `explore-analyze/workflows/` (e.g., Elastic Security Cases UI, Fleet, APM, Kibana app guides)
+- Feature how-tos for using a product in the Kibana UI when the deliverable is not a Workflows documentation page
+- Requests to document workflow YAML or steps as part of a non-Workflows docset
+
+Do **not** satisfy an out-of-scope request by reframing it — for example, turning a Security Cases UI request into a Workflows use-case page, or parking product feature content under a Workflows path for convenience.
+
+When declining, respond with:
+
+1. A clear statement that the request is outside this skill's scope
+2. What this skill covers (`explore-analyze/workflows/` pages only)
+3. A pointer to the appropriate product docset or docs workflow, without drafting the out-of-scope content
+
+Re-check scope after reading a doc issue in Step 0. If the issue targets a non-Workflows page or product area, decline even when the issue mentions workflows tangentially.
+
+## Inputs
+
+`$ARGUMENTS` is one of:
+
+- A **doc issue** — GitHub issue URL or `owner/repo#number` (preferred when one exists)
+- A **page idea or outline** (e.g., "document the `kibana.SetAlertsStatus` step")
+- A **file path** to draft or update (relative to docs-content or absolute)
+- A **workflow YAML sample** to turn into documentation
+- Any combination of the above in free text
+
+If empty, start with **Step 0: Intake** — do not jump straight to drafting.
+
+## Companion skills and tools
+
+This skill works standalone. These optional resources from the [elastic-docs-skills](https://github.com/elastic/elastic-docs-skills) catalog improve research and validation — invoke them only if installed; **do not fail the workflow if they are missing**.
+
+| Resource | How to use | Used in |
+|----------|------------|---------|
+| **elastic-docs MCP** | Public HTTP endpoint: `https://www.elastic.co/docs/_mcp/` (no auth). Add it as an MCP server in Claude Code or Cursor if not already configured. Test: `npx @modelcontextprotocol/inspector --url https://www.elastic.co/docs/_mcp/` | Step 2 |
+| **content-type-checker** | `/content-type-checker` — catalog: [skills/authoring/content-type-checker](https://github.com/elastic/elastic-docs-skills/tree/main/skills/authoring/content-type-checker) | Steps 1, 6 |
+| **docs-syntax-help** | `/docs-syntax-help` — catalog: [skills/authoring/docs-syntax-help](https://github.com/elastic/elastic-docs-skills/tree/main/skills/authoring/docs-syntax-help) | Step 4 |
+
+Install a companion skill: `npx skills@latest add elastic/elastic-docs-skills --skill content-type-checker -g`
+
+When the elastic-docs MCP is unavailable, fall back to **WebFetch** on `https://www.elastic.co/docs/...` URLs for the same research steps.
+
+## Step 0: Intake from the doc issue
+
+Gather scope and resolve open questions before classifying or researching.
+
+### 0a. Get the doc issue
+
+If `$ARGUMENTS` does not include an issue reference, use `AskUserQuestion`:
+
+> **Do you have a doc issue for this work?** Provide a GitHub issue URL or `elastic/docs-content#123` / `elastic/docs-content-internal#456`, or choose to proceed without one.
+
+Doc issues live in one of two repos:
+
+| Repo | Use |
+|------|-----|
+| `elastic/docs-content` | Public documentation issues |
+| `elastic/docs-content-internal` | Internal planning and drafting issues |
+
+Accept:
+
+- Full URL: `https://github.com/elastic/docs-content/issues/123` or `https://github.com/elastic/docs-content-internal/issues/456`
+- Shorthand: `elastic/docs-content#123`, `elastic/docs-content-internal#456`, or `docs-content-internal#456`
+- Bare `#123` — **do not assume a repo**; ask which repo via `AskUserQuestion`
+
+If the user has no issue, skip to Step 1 with whatever context they provide. Note in the output that no issue was supplied.
+
+### 0b. Read the issue
+
+Resolve the repo from the issue reference:
+
+1. **Full URL** — extract `docs-content` or `docs-content-internal` from the path
+2. **Shorthand** — use the repo named before `#`
+3. **Bare number** — ask the user to choose `elastic/docs-content` or `elastic/docs-content-internal`
+
+Fetch with the GitHub CLI (substitute the resolved repo):
+
+```bash
+gh issue view <number> --repo elastic/docs-content --json title,body,comments,labels
+# or
+gh issue view <number> --repo elastic/docs-content-internal --json title,body,comments,labels
+```
+
+Both repos use the same intake fields and open-question parsing — treat them identically after fetch.
+
+From the issue, extract and keep a running **intake summary**:
+
+| Field | Where to look |
+|-------|---------------|
+| Page scope | Title, **Scope**, **Summary**, or first paragraph |
+| Page type | Explicit label, or infer from wording (reference, how-to, use case, etc.) |
+| Target path | File path, proposed location, or linked draft PR |
+| Audience / product area | Labels, body sections, `applies_to` hints |
+| Source material | Linked PRs, Kibana issues, YAML samples, Figma, SME names |
+| Acceptance criteria | Checklist items, "done when" statements |
+| **Suggested doc work** | **`## Suggested documentation work (for the writer)`**, **`## Docs work`**, or similar — see Step 0c |
+| **Timeline / release** | `Timeline & environment`, stack version, serverless release date |
+| **Consolidation notes** | `Consolidation notes`, `Reconciled note`, superseded issue references — authoritative maturity wins |
+| **Open questions** | See parsing rules in Step 0d |
+
+Also read issue **comments** — answers and clarifications to suggested work may already be there.
+
+### 0c. Extract suggested documentation work
+
+Locate the writer brief in the issue `body`. Match any of these headings (case-insensitive):
+
+- `## Suggested documentation work (for the writer)`
+- `## Suggested documentation work`
+- `## Suggested edits`
+- `## Docs work`
+
+If none of these headings exist, treat numbered deliverables under `## Description` or similarly titled sections as the writer brief when they list concrete file paths and editing tasks.
+
+1. Extract every bullet, checklist item, and numbered task — include sub-bullets and nested items
+2. Parse what each item implies:
+   - **New page** vs **update to existing page** (note file paths when given)
+   - **Mirror page** — when the issue says "modeled on" or "reuse the structure of" an existing page (e.g., `cases.md`), read that page in Step 2 and match its section order, table layout, and includes
+   - **Multi-file deliverables** — primary page plus hub/index/cross-ref updates (e.g., `action-steps.md`, `step-types.md`, `cheat-sheet.md`, sibling step pages)
+   - **Shared conventions** — namespace-wide behavior to document once before per-step sections (bulk IDs, add/remove semantics, auth model)
+   - **Sections to add** (e.g., "Add a `Before you begin` section", "Document output shape")
+   - **Examples or YAML** to include — when the issue embeds parameter tables or YAML, treat them as draft input but **verify against Kibana source** in Step 2
+   - **Cross-links**, **preferred-namespace guidance**, or index/cheat-sheet updates
+   - **Pages to avoid duplicating** or content to remove
+3. Check comments for amendments, deferrals, or scope cuts to these suggestions
+4. Read **Consolidation notes** or **Reconciled note** sections — when an issue supersedes absorbed issues, use this issue's authoritative position for maturity (`applies_to`), availability, and scope. Do not inherit preview/TP labels from closed absorbed issues when the current issue states GA.
+
+Track each deliverable (not just the primary page) through drafting with status:
+
+| Status | Meaning |
+|--------|---------|
+| **Addressed** | Reflected in the draft |
+| **Deferred** | Out of scope for this pass — note why (user decision or issue comment) |
+| **Blocked** | Cannot draft without unresolved question or missing source |
+
+Present suggested work in the intake summary before drafting:
+
+```markdown
+## Suggested documentation work
+| # | Suggestion (from issue) | Status |
+|---|-------------------------|--------|
+| 1 | Add example for `workflow.execute` composition | Addressed — see "Combine actions" section |
+| 2 | Link from step type index | Deferred — follow-up edit listed below |
+| 3 | Document preview availability | Blocked — awaiting answer to open question #2 |
+```
+
+**Do not invent content that contradicts or ignores these suggestions.** If a suggestion is unclear, ask the user before drafting. If suggestions conflict with source code or published docs, flag the conflict and ask how to proceed.
+
+### 0d. Parse open questions
+
+Scan the issue `body` and `comments` for unresolved items. Common locations and formats:
+
+- Headings: `## Open items to confirm before publishing`, `## Open questions`, `## Questions`, `## Unknowns`, `## Decisions needed`
+- Checklist items still open: `- [ ] ...`
+- Explicit markers: `TBD`, `TODO`, `?`, `Need input from`, `Blocked on`
+- Numbered or bulleted questions ending with `?`
+
+For each question, classify as:
+
+- **Resolved** — answered in the issue body, a comment, or a linked PR/description
+- **Unresolved** — still open or contradictory across comments
+- **Researchable** — answerable from Kibana source or published docs without asking the user (handle in Step 2; do not ask the user)
+
+Present the parsed list to the user before drafting:
+
+```markdown
+## Intake summary
+- **Issue**: elastic/docs-content-internal#456 — <title>
+- **Scope**: ...
+- **Page type**: ...
+- **Target path**: ...
+
+## Suggested documentation work
+| # | Suggestion (from issue) | Status |
+|---|-------------------------|--------|
+| 1 | ... | Addressed / Deferred / Blocked |
+
+## Open questions
+| # | Question | Status |
+|---|----------|--------|
+| 1 | ... | Resolved — see comment by @user |
+| 2 | ... | Unresolved |
+| 3 | ... | Researchable — will verify in Kibana source |
+```
+
+### 0e. Ask the user to answer unresolved questions
+
+If any questions are **Unresolved**, use `AskUserQuestion` to collect answers. Rules:
+
+- Ask only **unresolved** questions — skip resolved and researchable items
+- Batch related questions in one form when possible (max ~5 per round)
+- Quote the original question text from the issue so the user recognizes it
+- If a question has multiple-choice options implied by the issue, offer those as choices plus **Other**
+
+Example prompt:
+
+> The doc issue lists these open questions. Please answer before I draft:
+> 1. Should this page cover stack 9.4 only or include 9.5+ inputs placement?
+> 2. Is `workflow.executeAsync` in scope or out of scope for this use case page?
+
+**Do not proceed to Step 2 (research) or Step 4 (draft)** until:
+
+- All unresolved questions have answers, **or**
+- The user explicitly says to proceed with stated assumptions (record those assumptions in the output)
+
+After answers are collected, update the intake summary and suggested-work status table. If an answer changes page type, target path, or scope of suggested work, re-check classification in Step 1.
+
+## Step 1: Classify the page
+
+Determine which page type to draft. Use the **intake summary** and **suggested documentation work** from Step 0 when available. Ask one focused question if still unclear.
+
+| Page type | Typical location | Content type | Example |
+|-----------|------------------|--------------|---------|
+| **Step reference** | `explore-analyze/workflows/steps/` | Reference | Elasticsearch action steps |
+| **Use case** | `explore-analyze/workflows/use-cases/` | Overview / explanation | Security workflows |
+| **Authoring technique** | `explore-analyze/workflows/authoring-techniques/` | How-to | Manage and organize workflows |
+| **Concept** | `explore-analyze/workflows/concepts/` | Explanation | Triggers, Steps, Liquid |
+| **Reference** | `explore-analyze/workflows/reference/` | Reference | Cheat sheet, step type index |
+| **Tutorial** | `explore-analyze/workflows/get-started/` | Tutorial | Build your first workflow |
+| **Hub / overview** | `explore-analyze/workflows/` or a section index | Overview | Workflows, Use cases |
+
+Run [`/content-type-checker`](https://github.com/elastic/elastic-docs-skills/tree/main/skills/authoring/content-type-checker) in classify mode when the page type is ambiguous — skip if not installed.
+
+## Step 2: Research before writing
+
+Never guess step types, parameter names, or UI labels. Gather facts first.
+
+### Published docs (preferred)
+
+Use the **elastic-docs** MCP server at `https://www.elastic.co/docs/_mcp/` (see **Companion skills and tools** for setup). If MCP is unavailable, use WebFetch on the same `https://www.elastic.co/docs/...` URLs.
+
+1. `search_docs` — find existing pages on the topic and related building blocks
+2. `get_document_by_url` — fetch sibling pages, templates, and guidelines with `includeBody: true`
+3. `find_related_docs` — discover cross-link targets
+
+Always read these anchors before drafting:
+
+| Resource | URL path |
+|----------|----------|
+| Workflows hub | `/docs/explore-analyze/workflows` |
+| Cheat sheet (gotchas) | `/docs/explore-analyze/workflows/reference/cheat-sheet` |
+| Step type index | `/docs/explore-analyze/workflows/reference/step-types` |
+| Anatomy reference | `/docs/explore-analyze/workflows/authoring-techniques/anatomy` |
+| Choose the right step | `/docs/explore-analyze/workflows/authoring-techniques/choose-the-right-step` |
+
+### Kibana source code
+
+When documenting a step type, trigger, or UI workflow:
+
+1. Search the Kibana repo for the step type identifier (e.g., `elasticsearch.search`, `cases.addComment`, `kibana.SetAlertsStatus`, `slack.postMessage`, `foreach`)
+2. Read the step definition, schema, or connector action registration — not just examples
+3. Confirm parameter names, required fields, and output shape
+
+Likely starting points in Kibana — search by step type ID first, then use the path that matches what you are documenting:
+
+| What you need | Where to look |
+|---------------|---------------|
+| **Step parameters, workflow YAML schema, deprecations** | `src/platform/packages/shared/kbn-workflows/spec/` — start with `schema.ts`, `builtin_step_definitions.ts`, `builtin_trigger_definitions.ts`, and namespace dirs `spec/elasticsearch/`, `spec/kibana/` |
+| **A specific step type** (`elasticsearch.search`, `cases.addComment`, `security.setAlertStatus`, `kibana.SetAlertsStatus`, `slack.postMessage`, `foreach`, etc.) | `kbn-workflows/spec/<namespace>/` for namespaced steps; `builtin_step_definitions.ts` for built-ins like `foreach`; then the registering plugin via repo search |
+| **Triggers** (manual, scheduled, alert, event-driven) | `kbn-workflows/spec/builtin_trigger_definitions.ts`; product triggers in registering plugins; `workflows_extensions/dev_docs/TRIGGERS.md` |
+| **UI labels, step menu, YAML editor, authoring surfaces** | `src/platform/plugins/shared/workflows_management/public/`; server-side step discovery in `workflows_management/server/` |
+| **Execution lifecycle, error handling, step output shape** | `src/platform/plugins/shared/workflows_execution_engine/` |
+| **Custom or product-registered steps** | `src/platform/plugins/shared/workflows_extensions/`; internal guide at `workflows_extensions/dev_docs/STEPS.md` |
+| **Stack connector actions** | `x-pack/platform/plugins/shared/stack_connectors/` and connector-specific plugins under `x-pack/platform/plugins/` |
+
+Official example workflows live in `kbn-workflows/spec/examples/`. Prefer these over `elastic/workflows` when verifying schema-valid YAML.
+
+**Note:** `x-pack/platform/plugins/shared/workflows/` is a legacy path — use the `src/platform/` layout above.
+
+### Existing docs-content files
+
+If a docs-content checkout exists in the workspace:
+
+- Read sibling pages under `explore-analyze/workflows/` for voice, structure, and cross-links
+- Check `explore-analyze/workflows/_snippets/` for reusable includes
+- Check `toc.yml` for navigation placement and whether the target is a hub page with `children:`
+
+### Example workflows
+
+The `elastic/workflows` library contains example YAML. Use it for realistic examples, but verify each step type and parameter against source before documenting.
+
+## Step 3: Apply Workflows authoring rules
+
+These conventions are non-negotiable. The [cheat sheet](https://www.elastic.co/docs/explore-analyze/workflows/reference/cheat-sheet) is the authority for gotchas.
+
+### YAML examples
+
+- Use `steps:` blocks for step-focused examples; include full workflow YAML only when triggers, inputs, or settings matter
+- Indent with two spaces; keep examples copy-pasteable
+- Name steps descriptively (`search_for_alerts`, not `step1`)
+- Show data flow between steps explicitly (`steps.<name>.output`)
+
+### Syntax rules
+
+| Rule | Correct | Wrong |
+|------|---------|-------|
+| Arrays/objects in Liquid | `"${{ event.alerts }}"` | `"{{ event.alerts }}"` |
+| Strings in Liquid | `"{{ inputs.name }}"` | — |
+| `data.filter` / `if` conditions | KQL: `item._source.severity : 'critical'` | Liquid: `==` comparisons |
+| Cases step parameters | `case_id`, `comment` (snake_case) | `caseId` (camelCase) |
+| Namespaced step IDs (`cases.*`, `security.*`, `elasticsearch.*`) | Lowercase dot notation: `security.setAlertStatus` | PascalCase (`kibana.SetAlertsStatus`) unless documenting the legacy step itself |
+| Alert status steps | `kibana.SetAlertsStatus` (PascalCase) | `kibana.set_alerts_status` |
+| AI step identifiers | Top-level `connector-id`, `agent-id` (literal kebab-case) | Nested under `with`, or Liquid-templated |
+| JSON serialization | `\| json`, `\| json_parse` | `to_json` (does not exist) |
+| `switch.cases` | Array of `{ case:, steps: }` objects | Map/object keyed by case value |
+| `workflow.execute` target | `workflow-id` inside `with` | Top-level field |
+
+### Version differences
+
+When examples involve `inputs`, show both placements with an applies-switch or tabs:
+
+- **Stack 9.4 and earlier**: top-level `inputs:`
+- **Stack 9.5+ and Serverless**: `inputs` nested under `type: manual` trigger
+
+Fetch anatomy.md for the canonical tab markup.
+
+### Lifecycle and availability
+
+Note preview/GA status and `applies_to` tags when a step or feature is version-gated. For deprecated or renamed steps, triggers, or parameters:
+
+- **New content** documents the current replacement, not the deprecated form
+- **Migration context** — if you show a deprecated form, mark it deprecated inline and link to the replacement reference
+- **Migration guides** — search the Workflows docset for version-specific migration pages (e.g., 9.3 → 9.4) and link to them; use `cases.*` instead of `kibana.createCase`-style steps as one example, not the only case
+- **Preferred namespace** — when new namespaced steps (`security.*`, `cases.*`) overlap legacy `kibana.*` PascalCase steps, document the namespaced steps as the preferred path for new workflows and add a cross-reference on the older page (mirror how `kibana.md` points to `cases.*`)
+
+## Step 4: Draft the page
+
+When a doc issue was provided, draft content that **addresses every item** in `## Suggested documentation work (for the writer)` unless explicitly deferred. Map each suggestion to a section, example, or follow-up edit in the draft.
+
+Follow the page-type structure in the sections below. H1 patterns, opening paragraphs, and section order are defined there.
+
+Workflows pages use a small set of MyST directives — apply these directly:
+
+- **Version splits** — `applies-switch` or tabs for YAML that differs by stack/serverless version (especially `inputs` placement). Copy markup from `anatomy.md`; do not invent tab syntax.
+- **UI walkthroughs** — `stepper` in authoring-technique pages only.
+- **Snippets** — `:::{include}` from `explore-analyze/workflows/_snippets/` when a matching snippet exists.
+
+Consult [`/docs-syntax-help`](https://github.com/elastic/elastic-docs-skills/tree/main/skills/authoring/docs-syntax-help) only for a directive you cannot resolve from sibling Workflows pages — skip if not installed.
+
+### Frontmatter
+
+```yaml
+---
+navigation_title: <Short nav label>   # omit on hub pages when title suffices
+description: <One sentence for search and tooltips — include "workflow" and the specific topic>
+products:
+  - id: kibana
+  - id: cloud-serverless    # include when feature is available on serverless
+applies_to:
+  stack: ga 9.4+            # adjust per feature availability
+  serverless: ga
+---
+```
+
+Add `type: how-to` or `type: tutorial` when the content type guidelines require it.
+
+### Step reference pages
+
+**File**: `explore-analyze/workflows/steps/<topic>.md` (or a subfolder under `steps/`)
+
+When the issue says to model on an existing step page (e.g., Cases action steps), read that sibling page first and mirror its layout rather than inventing a new structure.
+
+**Namespace / action-step family pages** (e.g., `cases.md`, `security.md`, `kibana.md`) use this structure:
+
+1. **H1 + anchor** — name the step family (e.g., "Security Triage and Investigation action steps"); set `navigation_title` shorter (e.g., `Security`)
+2. **Introduction** — what the `namespace.*` steps do, when to use them, and how they relate to overlapping steps on other pages
+3. **Shared conventions** — namespace-wide rules before per-step detail:
+   - Parameters under `with`
+   - Single vs bulk ID fields
+   - Add/remove semantics (preserve existing values; not full replace) when applicable
+   - Required-field rules (e.g., "at least one of add/remove")
+   - Parameter naming differences across related step groups — **document exactly as implemented; do not normalize** (e.g., `alert_ids` vs `ids`, `close_reason` vs `reason`)
+4. **Step catalog** — jump links to each step, grouped by subdomain when helpful (e.g., Alerts vs Attacks)
+5. **Per-step sections** — for each step type:
+   - One-sentence purpose
+   - Parameter table: `Parameter | Location | Type | Required | Description`
+   - YAML example
+6. Include `:::{include} ../_snippets/schema-location-legend.md :::` when the mirror page uses it
+7. **Related** — sibling step pages, triggers, step type index, cheat sheet
+
+**Other step reference pages** may also use:
+
+- **Overview table** — step type → API/operation mapping
+- **Combine actions** — multi-step example showing data flow (search → foreach → action)
+- **Key concepts** — output paths, loop variables, field reads for composition (e.g., reading alert fields before an assign step)
+
+For a **single step type** addition to an existing namespace page, document:
+
+- Required and optional `with` parameters (table format above)
+- Top-level fields (`connector-id`, `if`, `foreach`, `on-failure`, etc.)
+- Output shape (`steps.<name>.output`)
+- One minimal example and one realistic multi-step example when helpful
+- Gotchas specific to that step
+
+After drafting a new namespace page or step, list follow-up edits for:
+
+- **`steps/action-steps.md`** — add a category blurb + link when introducing a new step family
+- **`reference/step-types.md`** — add rows for every new step type
+- **`reference/cheat-sheet.md`** — add rows or update task-oriented groupings (e.g., "Manage alerts", "Manage attacks")
+- **Overlapping sibling pages** — cross-reference preferred namespace (e.g., `kibana.md` → `security.*`)
+
+### Use case pages
+
+**File**: `explore-analyze/workflows/use-cases/<domain>.md`
+
+**Structure**:
+
+1. **H1 + anchor** — domain-focused title (e.g., "Security workflows")
+2. **Introduction** — what teams accomplish with workflows in this domain
+3. **Pattern sections** — group by intent, not by step type:
+   - What you can automate (bullet list of outcomes)
+   - Typical triggers and step patterns (brief, with links to step/trigger reference)
+   - Pointers to example workflows or templates when they exist
+4. **Related** — links to relevant step references, authoring techniques, and tutorials
+
+Use case pages are shorter than step references. Link out rather than duplicating parameter tables.
+
+### Authoring technique pages (how-tos)
+
+**File**: `explore-analyze/workflows/authoring-techniques/<action-verb-topic>.md`
+
+Follow the [how-to content type guidelines](https://www.elastic.co/docs/contribute-docs/content-types/how-tos):
+
+1. **Action-verb H1** — e.g., "Monitor workflow execution"
+2. **Introduction** — outcome the reader will achieve
+3. **Before you begin** — permissions, prerequisites, UI access path
+4. **Numbered steps** — imperative verbs, one action per step; use `stepper` for UI walkthroughs
+5. **Success checkpoints** — how to confirm each critical step worked
+6. **Next steps** and **Related**
+
+Keep how-tos to ≤10 steps. Chain into a tutorial if the scope is broader.
+
+### Concept and reference pages
+
+**Concepts** explain triggers, steps, data flow, Liquid, error handling — focus on mental models and links to reference detail.
+
+**Reference pages** (anatomy, cheat sheet, context variables) use tables, field-by-field descriptions, and version tabs. Prefer tables over prose for parameter catalogs.
+
+### Tutorial pages
+
+**File**: `explore-analyze/workflows/get-started/<topic>.md`
+
+Follow tutorial content type guidelines. Chain multiple tasks with explanatory context. Include sample data setup, checkpoints, and a "what you built" summary.
+
+## Step 5: Cross-link and navigation
+
+After drafting:
+
+1. Add links **to** the new page from hub pages, step type index, cheat sheet, or choose-the-right-step as appropriate
+2. Add a **Related** section at the bottom of the new page (3–5 links)
+3. Update **`steps/action-steps.md`** when adding a new step family — match existing category blurbs (short description, "Use … to:" bullets, `Refer to …` link)
+4. Update **`reference/step-types.md`** and **`reference/cheat-sheet.md`** when the issue lists them as deliverables — do not stop at the primary page draft
+5. Add **preferred-namespace cross-references** on overlapping sibling pages (e.g., steer new alert-triage workflows from `kibana.SetAlertsStatus` to `security.setAlertStatus`)
+6. Update `toc.yml` if adding a new file (confirm placement with the user)
+7. Remove duplicated content from hub pages — hubs summarize and link, they do not restate reference detail
+
+## Step 6: Validate
+
+Before presenting the draft:
+
+1. Run [`/content-type-checker`](https://github.com/elastic/elastic-docs-skills/tree/main/skills/authoring/content-type-checker) on the draft if installed — otherwise spot-check structure against the page-type templates in Step 4
+2. Validate outbound links — use elastic-docs MCP `get_document_by_url` (or WebFetch) to resolve each cross-link in the draft when a file path is available
+3. Spot-check YAML examples against the cheat sheet gotchas list
+4. Confirm step types and parameter names against Kibana source
+5. Cross-check the draft against the **suggested documentation work** table — every non-deferred item must be addressed or explained
+
+Report any items you could not verify against source. Note any companion skills or MCP tools that were unavailable.
+
+## Output format
+
+Present:
+
+1. **Intake summary** — issue link, scope, **suggested documentation work** (with status per item), resolved and unresolved questions (omit if no issue was used)
+2. **Page classification** — type, target file path, rationale
+3. **Research summary** — source pages read, Kibana files consulted
+4. **Draft content** — full markdown with frontmatter, ready to write to docs-content
+5. **Follow-up edits** — other files to update (index, toc.yml, hub links); include deferred items from suggested doc work
+6. **Open questions** — anything still needing SME review after drafting
+
+If the user provided a file path, write the draft to that path. Otherwise, propose the path and show the content for review first.

--- a/skills/project/docs-draft-workflow-docs/evals/evals.json
+++ b/skills/project/docs-draft-workflow-docs/evals/evals.json
@@ -1,0 +1,68 @@
+{
+  "skill_name": "docs-draft-workflow-docs",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Draft docs for elastic/docs-content#7089 — add the missing cases.removeTags workflow step to the Cases action steps reference. The issue links Kibana PR #268465 and says it belongs in the Tags and assignees section beside cases.addTags.",
+      "expected_output": "Runs doc-issue intake, classifies as an update to explore-analyze/workflows/steps/cases.md (not a new page), researches cases.removeTags from Kibana source, and drafts a cases.removeTags section following the cases.addTags pattern with parameter table and YAML example.",
+      "expectations": [
+        "Targets explore-analyze/workflows/steps/cases.md under the Workflows docset",
+        "Inserts cases.removeTags in the Tags and assignees section following cases.addTags structure",
+        "Documents case_id and tags parameters using snake_case in the with block",
+        "Includes a YAML usage example for cases.removeTags",
+        "Notes follow-up to update the step catalog line and step type index",
+        "Does NOT create a new standalone Cases feature doc outside explore-analyze/workflows/"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "elastic/docs-content-internal#1454 — Workflow visualization diagram (DAG) view behind an experimental advanced setting in 9.5. The suggested documentation work table splits ship-now MVP content from post-9.5 deferred items, and there are four open items to confirm before publishing.",
+      "expected_output": "Fetches the internal issue, extracts suggested documentation work with ship-now vs defer scope, presents unresolved open questions before drafting, and drafts only MVP content for a new authoring-techniques page plus follow-up edits for use-yaml-editor.md and toc.yml.",
+      "expectations": [
+        "Parses ## Suggested documentation work (for the writer) including ship now vs defer rows",
+        "Treats open items to confirm before publishing as unresolved questions requiring user input",
+        "Proposes explore-analyze/workflows/authoring-techniques/visualize-workflows.md for MVP scope",
+        "Drafts only ship-now items and lists deferred post-9.5 content as follow-up",
+        "Includes experimental/preview enablement for the workflows:experimentalFeatures advanced setting",
+        "Lists inbound link and toc.yml updates as follow-up edits rather than skipping them"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I have this workflow YAML and need a step reference entry for elasticsearch.esql.query. The step runs an ES|QL query and passes results to the next step via steps.run_esql.output.\n\nsteps:\n  - name: run_esql\n    type: elasticsearch.esql.query\n    with:\n      query: \"FROM logs-* | WHERE severity == \\\"critical\\\" | LIMIT 10\"",
+      "expected_output": "Classifies as a step reference update or addition, researches elasticsearch.esql.query in kbn-workflows/spec and Kibana source, applies Workflows YAML conventions, and drafts parameter documentation with a realistic example showing output chaining.",
+      "expectations": [
+        "Researches elasticsearch.esql.query in Kibana source rather than inventing parameters",
+        "Documents the with.query parameter and steps.<name>.output data flow",
+        "Places content under explore-analyze/workflows/steps/ not outside the Workflows docset",
+        "Applies Workflows authoring rules such as descriptive step names and copy-pasteable YAML",
+        "Suggests cross-links to the step type index and choose-the-right-step page"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Write documentation explaining how analysts create and manage cases in the Elastic Security UI — case statuses, assignees, connectors, and the case details flyout. Put it in the Security docs section.",
+      "expected_output": "Does NOT draft Security Cases UI documentation. Recognizes the request is outside the Workflows docset scope and declines or redirects to Workflows-only work under explore-analyze/workflows/.",
+      "expectations": [
+        "Does NOT draft general Elastic Security Cases UI documentation",
+        "Does NOT place content outside explore-analyze/workflows/",
+        "Recognizes this is outside the docs-draft-workflow-docs skill scope",
+        "Does NOT reframe the Security Cases UI request as a Workflows use-case page",
+        "Declines with a scope explanation instead of running Steps 0–6"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "elastic/docs-content#7222 — Document the six security.* alert and attack triage workflow steps for 9.5. The issue has a ## Docs work section with four deliverables: new security.md modeled on cases.md, updates to action-steps.md, a cross-ref on kibana.md preferring security.* over kibana.SetAlertsStatus, and step-types.md plus cheat-sheet.md updates. All six steps are GA in 9.5.",
+      "expected_output": "Parses ## Docs work as the writer brief, mirrors cases.md structure for a new security.md page with Shared conventions and per-step parameter tables, lists multi-file follow-up edits, and uses GA applies_to from the authoritative issue rather than absorbed preview notes.",
+      "expectations": [
+        "Parses ## Docs work (not only Suggested documentation work) as the writer brief",
+        "Proposes explore-analyze/workflows/steps/security.md modeled on cases.md",
+        "Documents Shared conventions including alert_ids vs ids and add/remove semantics",
+        "Lists follow-up edits for action-steps.md, kibana.md, step-types.md, and cheat-sheet.md",
+        "Recommends security.* as preferred over overlapping kibana.SetAlertsStatus steps",
+        "Uses stack: ga 9.5+ and serverless: ga applies_to per the authoritative issue"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `docs-draft-workflow-docs`, a project skill for drafting and updating Elastic Workflows documentation under `explore-analyze/workflows/`.
- Guides writers through doc-issue intake (from `elastic/docs-content` or `elastic/docs-content-internal`), page-type classification, Kibana source research, Workflows YAML/Liquid conventions, drafting templates, cross-linking, and validation.
- Includes four eval cases covering step-reference updates, new use-case pages, doc-issue-driven drafts, and an out-of-scope negative test.

## Usage

```bash
/docs-draft-workflow-docs elastic/docs-content#7089
```

After merge, install globally with:

```bash
npx skills@latest add elastic/elastic-docs-skills --skill docs-draft-workflow-docs -g
```

## Test plan

- [x] CI validates `SKILL.md` frontmatter and `evals/evals.json`
- [x] Install locally: `npx skills@latest add elastic/elastic-docs-skills --skill docs-draft-workflow-docs -g` (or copy from repo)
- [x] Run `/docs-draft-workflow-docs elastic/docs-content#7089` in Claude Code terminal and confirm intake + draft workflow
- [x] Run `/docs-draft-workflow-docs elastic/docs-content-internal#1454` and confirm suggested-doc-work parsing and open-question handling
- [x] Confirm out-of-scope request (e.g. Cases product docs outside Workflows docset) is rejected per eval expectations


Made with [Cursor](https://cursor.com)