### PR TITLE
remove h1 anchor requirement

### DIFF
--- a/skills/authoring/page-opening-optimizer/SKILL.md
+++ b/skills/authoring/page-opening-optimizer/SKILL.md
@@ -54,10 +54,9 @@ The H1 must be:
 1. **Discoverable** — include the feature name and context (e.g., "in Kibana", "with ES|QL")
 2. **Specific** — clearly indicate what the page covers
 3. **Unique** — no other page should share this title
-4. **Anchored** — always include `[anchor-name]` in brackets
 
 ```markdown
-# Configure data views in Kibana [configure-data-views]
+# Configure data views in Kibana
 ```
 
 If the H1 exceeds ~50 characters, add `navigation_title` to the frontmatter.
@@ -178,7 +177,7 @@ Before modifying any file, verify:
 ## Quality checklist
 
 - [ ] Doc type correctly identified
-- [ ] H1 is unique, specific, searchable, and has an anchor
+- [ ] H1 is unique, specific, searchable (no custom anchor — docs-builder auto-generates it)
 - [ ] `navigation_title` added if H1 > 50 characters
 - [ ] Opening paragraph doesn't repeat frontmatter description
 - [ ] Opening conveys purpose, value, and scope

--- a/skills/authoring/page-opening-optimizer/evals/evals.json
+++ b/skills/authoring/page-opening-optimizer/evals/evals.json
@@ -6,7 +6,6 @@
       "prompt": "Optimize the opening of this how-to page:\n\n---\ndescription: Learn how to use pattern analysis to find log patterns.\n---\n\n# Pattern analysis\n\nYou can use pattern analysis in Discover to find patterns in your log data. It helps you find common patterns.",
       "expected_output": "Improved H1 with anchor, a richer opening paragraph that defines what pattern analysis is and its value, and a suggestion to add a requirements section",
       "expectations": [
-        "Adds an anchor to the H1 (e.g., [pattern-analysis] or similar)",
         "Rewrites the opening paragraph to define what pattern analysis is and explain its value",
         "Does not repeat the frontmatter description verbatim in the opening paragraph",
         "Replaces 'Discover' with bold formatting (**Discover**) as a UI element",
@@ -30,7 +29,6 @@
       "expected_output": "Improved H1 with context and anchor, acronym spelled out on first use, version reference updated, substitutions applied",
       "expectations": [
         "Improves the H1 to be more discoverable (e.g., 'Query your data with ES|QL in Discover')",
-        "Adds an anchor to the H1",
         "Spells out the acronym on first use: 'Elasticsearch Query Language ({{esql}})'",
         "Removes the pre-9.0 version reference ('version 8.0 or later')",
         "Replaces hardcoded 'Kibana' with {{product.kibana}} substitution"


### PR DESCRIPTION
Remove incorrect H1 anchor requirement from page-opening-optimizer skill. docs-builder auto-generates H1 anchors, so custom ones are redundant noise (and don't link you deeper down the page).