### PR TITLE
feat: add docs-create-draft authoring skill

### DIFF
--- a/skills/authoring/create-draft/SKILL.md
+++ b/skills/authoring/create-draft/SKILL.md
@@ -1,0 +1,440 @@
+---
+name: docs-create-draft
+version: 1.2.0
+description: Draft a new Elastic documentation page from scratch. Use when writing a new doc page, when the user asks to document a feature or topic, or when a new page needs to be added to a docs repo. Engages the user for audience and purpose, classifies the correct content type, applies proper applies_to tags, searches related docs, and delivers a style-compliant draft with crosslinks. Ends with a subagent reading test.
+argument-hint: <topic-or-issue-url-or-file-path>
+context: fork
+allowed-tools: Read, Grep, Glob, Edit, Write, CallMcpTool, WebFetch, Bash(gh *), AskUserQuestion, Agent
+sources:
+  - https://www.elastic.co/docs/contribute-docs/content-types/overviews
+  - https://www.elastic.co/docs/contribute-docs/content-types/how-tos
+  - https://www.elastic.co/docs/contribute-docs/content-types/tutorials
+  - https://www.elastic.co/docs/contribute-docs/content-types/troubleshooting
+  - https://www.elastic.co/docs/contribute-docs/style-guide
+  - https://elastic.github.io/docs-builder/syntax/applies/
+  - https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/guidelines
+---
+<!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+or more contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright
+ownership. Elasticsearch B.V. licenses this file to you under
+the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. -->
+
+You are a documentation author for Elastic. Your job is to draft a new documentation page from scratch. You gather context from the user, choose the right content type, apply correct `applies_to` tags, search for related docs, write a style-compliant draft, and run a reading test via a subagent.
+
+## Inputs
+
+`$ARGUMENTS` is one of:
+
+- A **topic or feature name** — a short description of what the page should cover
+- A **GitHub issue URL** or `owner/repo#number` — a doc issue with scope, requirements, and context
+- A **file path** — where the finished file should be written
+- A **combination** of the above
+
+If empty, start at **Step 1: Intake** and ask the user what to document.
+
+---
+
+## Step 1: Intake
+
+Gather the minimum context needed to draft the page. Use `AskUserQuestion` to ask one round of questions. Do not start research or drafting until you have answers.
+
+Ask all of these questions in a single `AskUserQuestion` call:
+
+1. **Audience** — Who is this page for? (Operators, developers, end users, admins, or a mix?) What skill level do they have with Elastic products?
+2. **Purpose** — What should readers be able to do or understand after reading this page?
+3. **Context** — Is there a GitHub issue, PR, Kibana issue, or design doc for this work? Paste a URL or reference if so.
+4. **Target location** — Do you know where in the docs this page should live (product, section, or file path)? If not, leave blank.
+
+### 1a. Resolve issue context
+
+If the user provides a GitHub issue URL or shorthand (`owner/repo#number`), fetch it:
+
+```bash
+gh issue view <number> --repo <owner>/<repo> --json title,body,comments,labels
+```
+
+Extract:
+- Page scope and purpose
+- Target file path (if given)
+- Audience or product labels
+- `applies_to` hints (stack version, serverless)
+- Open questions or acceptance criteria
+
+If the issue has open questions that are still unresolved and material to drafting, ask the user to answer them before proceeding.
+
+### 1b. Gather repo context
+
+Look for an existing docs repo in the current workspace. Check for:
+
+- A `docset.yml`, `toc.yml`, or `book.json` to understand the navigation structure
+- Sibling `.md` files near the intended location to understand voice, structure, and formatting conventions
+- An `applies_to` pattern in nearby files to infer the correct version scope
+- Product substitution variables in use (for example, `{{product.kibana}}`, `{{esql}}`)
+
+If no docs repo is present, note that and proceed with Elastic documentation conventions as defaults.
+
+---
+
+## Step 2: Classify the content type
+
+Determine which content type the page should use before drafting.
+
+Fetch the content type guidelines using the `elastic-docs` MCP `get_document_by_url` tool with `includeBody: true`. Use these URLs:
+
+| Content type    | Guidelines URL |
+|-----------------|----------------|
+| overview        | https://www.elastic.co/docs/contribute-docs/content-types/overviews |
+| how-to          | https://www.elastic.co/docs/contribute-docs/content-types/how-tos |
+| tutorial        | https://www.elastic.co/docs/contribute-docs/content-types/tutorials |
+| troubleshooting | https://www.elastic.co/docs/contribute-docs/content-types/troubleshooting |
+
+If the MCP is unavailable, fetch the `.md` suffix versions directly via WebFetch.
+
+Match the user's purpose against the content type definitions:
+
+- **Overview** — describes what something is, how it works, and why it matters. No long procedures.
+- **How-to** — one self-contained task. Action-verb title, numbered steps, success checkpoint.
+- **Tutorial** — chains related tasks toward a learning outcome. Has objectives, prerequisites, checkpoints.
+- **Troubleshooting** — resolves one specific repeatable problem. Symptoms section, Resolution section.
+
+When the purpose contains sequential steps and prerequisites, prefer **how-to** over overview. When it describes a symptom or error, prefer **troubleshooting**. When it chains multiple tasks for beginners, prefer **tutorial**.
+
+If the classification is ambiguous, ask one focused clarifying question.
+
+If no standard content type fits — for example, a landing page, a cross-product hub, a product glossary, or a content form the types above do not cover — use a free-form structure appropriate to the purpose. Notify the user explicitly that the page does not map to a formal content type, explain why, and describe the structure you will use instead. Do not force an ill-fitting content type onto a page to avoid this case.
+
+Fetch the content type template:
+
+| Content type    | Template URL |
+|-----------------|--------------|
+| overview        | https://raw.githubusercontent.com/elastic/docs-content/main/contribute-docs/content-types/_snippets/templates/overview-template.md |
+| how-to          | https://raw.githubusercontent.com/elastic/docs-content/main/contribute-docs/content-types/_snippets/templates/how-to-template.md |
+| tutorial        | https://raw.githubusercontent.com/elastic/docs-content/main/contribute-docs/content-types/_snippets/templates/tutorial-template.md |
+| troubleshooting | https://raw.githubusercontent.com/elastic/docs-content/main/contribute-docs/content-types/_snippets/templates/troubleshooting-template.md |
+
+Use the template as the structural skeleton for the draft.
+
+---
+
+## Step 3: Research related content
+
+Use the `elastic-docs` MCP to discover existing pages on the topic. If MCP is unavailable, use WebFetch on `https://www.elastic.co/docs/...` URLs.
+
+Run these searches:
+
+1. `search_docs` — search for pages on the same topic. Look for duplicates that could make the new page redundant.
+2. `find_related_docs` — discover candidate crosslink targets (overview pages, how-tos, reference pages).
+3. `check_docs_coherence` — check whether the topic is already covered coherently. If it is, note any gaps the new page should fill.
+
+Record:
+- URLs of pages to crosslink **to** from the new page
+- URLs of hub or index pages that should crosslink **back** to the new page
+- Any content on existing pages that this new page should not duplicate
+
+If a very similar page already exists, surface it to the user before drafting and ask whether to create a new page or extend the existing one.
+
+---
+
+## Step 4: Build the frontmatter
+
+Construct the YAML frontmatter before writing the body.
+
+### Required fields
+
+```yaml
+---
+navigation_title: <~30 chars — omit when the H1 already fits or the nav hierarchy removes redundancy>
+meta_title: <{H1} - {Product} | Elastic Docs — set only for Pattern B pages; see Title layers below>
+description: <One sentence for search, 120–200 characters. Action-oriented, no "you can" or "this page explains". Plain text only — no Jinja2 variables.>
+type: <overview | how-to | tutorial | troubleshooting>
+products:
+  - id: <product-id>          # for example: kibana, elasticsearch, cloud-serverless
+applies_to:
+  stack: <lifecycle version>  # for example: ga 9.0+
+  serverless: <lifecycle>     # for example: ga
+---
+```
+
+`meta_title` is a proposed field (not yet implemented in docs-builder). Set it in the frontmatter now so it is ready when the field is available. Until then, Pattern B pages fall back to `{H1} | Elastic Docs` without the product qualifier.
+
+### Derive applies_to
+
+Ask the user for any version or deployment constraints if the issue or context does not specify them.
+
+Apply these rules:
+
+- Use `stack: ga` with a `x.x+` version for features available from a specific Stack release onward.
+- Use `serverless: ga` (no version) for features available on Serverless.
+- Use `serverless: unavailable` when the feature is Stack-only.
+- When the feature is in preview or beta, use the appropriate lifecycle state: `stack: preview 9.x+`.
+- Omit version if the feature has been available since before Stack 9.0.
+
+Base the choice on the available context.
+
+If the feature scope is unclear, ask one focused question before proceeding.
+
+Fetch the applies_to guidelines if needed:
+
+- https://elastic.github.io/docs-builder/syntax/applies/
+- https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs/guidelines
+
+---
+
+## Step 5: Draft the page
+
+Write the full page content following the template from Step 2.
+
+### Title layers
+
+Every page has three title surfaces. Set them in this order.
+
+| Layer | Where it appears | Frontmatter field | Target length |
+|-------|-----------------|-------------------|---------------|
+| Page title | Search results, browser tab, social sharing | `meta_title` (falls back to H1 + ` \| Elastic Docs`) | ~60 chars total |
+| H1 | Top of the page | First `#` heading | ~45 chars |
+| Navigation title | Left sidebar | `navigation_title` (falls back to H1) | ~30 chars |
+
+The page title must be self-contained for search. The H1 can rely on the surrounding page for context. The navigation title can rely on the nav hierarchy.
+
+#### H1 rules
+
+- **Task pages (how-to, tutorial)** — imperative verb phrase: _Install Elasticsearch with Docker_, _Monitor cluster health_.
+- **All other pages** — noun phrase: _Index lifecycle management in Elasticsearch_.
+- Do not start with "How to" or a gerund (-ing form).
+- **Tutorial pages**: prefix with `Tutorial:` — for example, _Tutorial: Semantic search with Elasticsearch_.
+- **Quickstart pages**: prefix with `Quickstart:` — for example, _Quickstart: Elasticsearch local development_.
+- **Include the product name** when the H1 would be ambiguous or non-unique without it:
+  - Feature of a product: "in {Product}" — _Logging settings in Kibana_
+  - Method or tool: "with {Tool}" — _Install Elasticsearch with Docker_
+  - Parent topic: product leads the phrase, no preposition — _Elasticsearch installation_
+- **Exception**: well-known, Elastic-specific names (Query DSL, ES|QL, Painless) may omit the product from the H1 and use Pattern B for the page title instead.
+- Every H1 must be unique across the site. Differentiate same-topic pages by product.
+- Sentence case. Always capitalize product names and proper nouns.
+
+#### H1 by content type
+
+| Content type | H1 form | Example |
+|---|---|---|
+| Overview | Noun phrase with product name | _Index lifecycle management in Elasticsearch_ |
+| How-to | Imperative verb + object | _Configure Fleet server TLS_ |
+| Tutorial | `Tutorial:` + noun phrase | _Tutorial: Semantic search with Elasticsearch_ |
+| Troubleshooting (dedicated) | User-perspective problem statement | _Logs missing after upgrading Elastic Agent_ |
+| Troubleshooting (wayfinding) | Noun phrase; "Troubleshoot X" acceptable | _Common Elasticsearch problems_ |
+| Configuration reference | `{Feature} settings in {Product}` — always use "settings" | _Logging settings in Kibana_ |
+| Reference | Noun phrase with product name — never "settings" | _Elasticsearch REST APIs_ |
+| Release notes | `{Product} release notes` — no version in H1 | _Elasticsearch release notes_ |
+| API operation | Imperative from OpenAPI summary; use "Get" not "Retrieve" | _Get connector types_ |
+| Parent topic | Noun phrase, product leads | _Elasticsearch installation_ |
+| Product/feature landing | Product or feature name only | _Elasticsearch_ |
+
+#### Page title patterns
+
+The suffix ` | Elastic Docs` is appended automatically (~15 chars). Do not type it manually. Account for it in your length budget.
+
+- **Pattern A** — H1 already includes the product name. No `meta_title` needed. The page title is `{H1} | Elastic Docs`.
+- **Pattern B** — H1 omits the product name. Set `meta_title: {H1} - {Product} | Elastic Docs`. Two cases:
+  - Product missing from H1: `Index fundamentals - Elasticsearch | Elastic Docs`
+  - Well-known feature name: `Query DSL - Elasticsearch | Elastic Docs`
+- **API operation pages** always use a fixed Pattern B variant: `{H1} - {Product} API | Elastic Docs`.
+
+#### Navigation title rules
+
+- Match the H1's wording — just trimmed. Do not introduce synonyms or abbreviations not in the H1.
+- Drop the product name when the nav section already identifies the product.
+- Drop content-type prefixes (`Tutorial:`, `Quickstart:`) when the nav groups pages by type.
+- Never trim so short that the label is ambiguous among its siblings.
+- If the H1 is already ~30 characters and has no redundant qualifier, omit `navigation_title`.
+
+### Opening paragraph
+
+Write 2–4 sentences immediately after the H1. The opening must not repeat the frontmatter `description`.
+
+- **Overview**: Define the feature, explain how it works, and state its value.
+- **How-to**: Define the feature, state the outcome the reader will achieve.
+- **Tutorial**: State what the tutorial covers and what the reader will learn.
+- **Troubleshooting**: Describe the symptom and which users encounter it.
+
+### Body content
+
+Follow the template structure for the classified content type. Key rules:
+
+- **One instruction per step** in procedural pages. Use numbered lists for steps, bullets for options.
+- **Before you begin / Prerequisites** — include only when requirements are non-obvious. List specific privilege levels, data requirements, and external systems.
+- **Code examples** — use fenced code blocks with a language hint. Name steps descriptively.
+- **UI element names** — bold. Commands, settings, field names — monospace.
+- **Product names** — use substitution variables when available: `{{product.kibana}}`, `{{product.elasticsearch}}`, `{{esql}}`.
+- **No versions in prose** alongside `applies_to` badges.
+- **Active voice, present tense, second person** throughout.
+
+### Crosslinks
+
+Add a `## Related` section at the end of the page. Include 3–5 links discovered in Step 3. Use descriptive link text — never bare URLs or "click here."
+
+Also flag any hub pages, index pages, or navigation files (`toc.yml`) that should link back to the new page, as follow-up edits.
+
+---
+
+## Step 6: Self-review
+
+Review the draft before presenting it to the user. Fix every violation you find. Do not report issues you could fix yourself.
+
+**Choose the checklist based on scope:**
+
+- **Full review** — use for all new pages created by this skill. This is the default.
+- **Light review** — use only when the skill is being used to add a small correction, clarification, or addition to a single existing page or section.
+
+---
+
+### Light review checklist
+
+Run this checklist when scope is limited to a correction or small addition on a single page.
+
+**User focus** — The change serves the user's task. Paragraphs are short. Lists, tables, and admonitions make the update scannable. Content sits in the right place on the page.
+
+**Technical accuracy** — Content is technically sound and confirmed by an SME or authoritative source (issue, Slack, eng review). Does not contradict the corpus. New code samples have been tested. If the change affects version, lifecycle, or deployment scope: prerequisites remain accurate; no new permission or setup dependency is left unstated.
+
+**Applicability** — Only if the change affects version, lifecycle, or deployment scope: `applies_to` values and placement are correct; the change is non-destructive for older versions; deployment type is scoped correctly.
+
+**Maintainability** — No duplicate procedure or value that already lives elsewhere (prefer a cross-reference or snippet). If images or snippets were removed, source files were cleaned up.
+
+**Language** — Follows word choice and grammar and spelling rules. Plain, minimal wording. Informational tone. No promotional language or superlatives. If UI copy is involved, follows UI writing rules.
+
+**Style and preview** — No directional terms, Latinisms, italics/bold for emphasis, "and/or," or "please." Formatting is consistent. No stacked admonitions. Link text is meaningful and links resolve. Title and H1 are still accurate and in sentence case. Preview is clean: badges render, tables and tabsets intact, no stray bullets or comments, no literal `{{` in snippets.
+
+---
+
+### Full review checklist
+
+Run this checklist for all new pages. Check every item. Fix what you can; flag what requires SME input as an open question in the output.
+
+#### User focus
+
+**Content completeness** — Focused on user intent, goals, and tasks. States the benefit of the feature or path. All impacted pages assessed and updated (including references that use new concepts). New features contextualized on the parent page against the product landscape.
+
+**Scannability** — Reasonable paragraph length. Lists, tables, and admonitions break up dense content. Lead-in sentences set topic boundaries and how to think about the subject.
+
+**Findability** — Correct IA placement. Strategic cross-references (especially from parent pages) so users are not stranded. Each page has a clear goal and matches an Elastic Docs content type. Screenshots and diagrams only when necessary. Instructions are clear and unambiguous. SEO and findability considered (see Title layers in Step 5).
+
+**Logical flow** — Most logical order and location. Progressive disclosure. Contrasting pairs for conceptual choices. Options include value propositions near decision points.
+
+#### Technical accuracy
+
+**Correctness** — SME-written or backed by an authoritative source (issue, eng review). Tested where possible. No contradictions with the docs corpus.
+
+**Precise prerequisites** — Permissions, setup, and assumed knowledge are stated. Deployment types and versions are called out in prerequisites when they differ from page-level tagging.
+
+#### Applicability
+
+**applies_to tags** — Product, version, and lifecycle specified correctly. Single applicability facet at page level (do not mix stack/serverless with deployment dimensions). Correct versioning scheme per product.
+
+**Cumulative structure** — Follows cumulative docs guidelines. Version-specific changes are tagged. For versioned products, changes are non-destructive and older information remains findable with correct lifecycle and range tags. For unversioned products, only current functionality is documented. No version tags on version-insensitive information.
+
+**Markup correctness** — Ranges, precise versions, and open-ended ranges (`x.x+`) are used correctly. Section-level and inline tags work with the page-level tag. Badge placement is correct.
+
+**Deployment types** — Scope is set correctly. Relevant deployment types are covered (or notes/paths provided for uncovered ones). Shared processes stay deployment-agnostic. Self-managed (vanilla Elasticsearch) is not conflated with the self/ECE/ECK grouping.
+
+**Scope discipline** — No roadmap commitments or future tense promises. No implementation details or decision history.
+
+#### Maintainability
+
+**Single source of truth** — Prefer cross-references or snippets over duplicated procedures or values.
+
+**Repository hygiene** — Do not manually edit generated or automated reference material. Unused images and snippets are removed. Redirects added for any retired or renamed anchors.
+
+**High-maintenance content** — Images, screenshots, diagrams, and non-Elastic external links justify ongoing maintenance cost. Flag any added for the open questions list if the maintenance burden is high.
+
+#### Language
+
+**Mechanics** — Grammar, spelling, and punctuation support clarity. Simplify punctuation where it helps.
+
+**Plain language and terminology** — Accessible to someone new to the topic. Jargon, acronyms, and internal terms are defined or linked on first use. Minimal wording. Informational tone. Consistent terms for ambiguous concepts. No promotional language or superlatives.
+
+**Word choice** — Fix these common violations:
+
+| Avoid | Use instead |
+|-------|-------------|
+| abort | cancel, stop, shut down |
+| above / below (positional) | the section title or a link |
+| blacklist / whitelist | blocklist / allowlist |
+| choose | select |
+| click (non-mouse context) | select |
+| e.g. / i.e. / etc. / via | for example / that is / and more / through |
+| easy, easily, simple, simply | *(remove — adds no value)* |
+| execute | run |
+| launch | open |
+| please | *(remove)* |
+| type (user input) | enter |
+| utilize | use |
+
+**Variables** — Version variables and substitution variables (`{{product.kibana}}`, `{{esql}}`, and so on) are used correctly. No hardcoded product names where a substitution variable exists.
+
+#### Style
+
+**Voice and tense** — Active voice except where passive is necessary. Present tense unless future is genuinely required. Second person ("you/your"). No "I/me." Use "we" only for "we recommend."
+
+**Flagged language** — No directional terms ("above," "below," "left," "right" for position), Latinisms ("e.g.," "i.e.," "etc."), parentheses cruft, italics or bold for emphasis (only for UI elements and new terms), "and/or," or "please."
+
+**Titles and headings** — Sentence case throughout. Describes the page distinctly from similar titles. Action-oriented where appropriate (gerund or verb for task headings). Content exists between consecutive headings (no empty headings). Consistent heading style at each level. Aim for 50–60 characters when practical.
+
+**Formatting and admonitions** — Formatting is consistent. Admonitions are used sparingly (roughly three or fewer nearby) so they still stand out. No back-to-back stacked admonitions; merge into one callout or the narrative where possible. Bold for UI elements. Monospace for commands, settings, file paths, values. Oxford comma in lists of three or more.
+
+**Links, accessibility, and preview** — Meaningful link text (never "click here" or bare URLs). New or changed links resolve. Tables and images have clear alt text and surrounding explanation. Preview is clean: badges render, no stray bullets or comments, tables and tabsets intact, no literal `{{` in snippets.
+
+---
+
+## Step 7: Reading test (subagent)
+
+After completing the draft, launch a subagent to perform a reading test. The subagent reads the draft as a first-time reader and reports problems.
+
+Use the `Agent` tool with this prompt, substituting the actual draft content:
+
+```
+You are a first-time reader of an Elastic documentation page. You have just enough background to be the target audience described below.
+
+**Target audience**: <audience from Step 1>
+**Page purpose**: <purpose from Step 1>
+
+Read the following draft page and answer these questions:
+
+1. After reading the opening paragraph, do you know exactly what this page is about and whether it applies to you? If not, what is confusing?
+2. Are there any steps, instructions, or concepts that assume knowledge the stated audience may not have?
+3. Are there any gaps — things you would need to know or do that the page does not cover?
+4. Are there any sections where you would stop reading because the content is unclear, too long, or out of order?
+5. Does the Related section point to useful next steps for someone who just finished reading?
+
+Report your findings as a numbered list. For each issue, state: the section or line where the problem occurs, what a reader would think or feel at that point, and a concrete suggestion to fix it. If the page reads clearly end to end, say so and explain why.
+
+**Draft content**:
+
+<draft content here>
+```
+
+Present the subagent's reading test report to the user alongside the draft.
+
+---
+
+## Output format
+
+Present results in this order:
+
+1. **Intake summary** — audience, purpose, GitHub issue (if any), target file path
+2. **Content type** — classified type, confidence, rationale
+3. **Research summary** — related pages found, coherence check result, any duplication risk
+4. **Draft** — full markdown with frontmatter, ready to save
+5. **Follow-up edits** — hub pages, `toc.yml` entries, or index pages to update
+6. **Reading test report** — subagent findings with suggestions
+7. **Open questions** — anything requiring SME input before publishing
+
+If the user provided a file path or confirmed one during intake, write the draft to that path. Otherwise, show the draft for review and ask the user to confirm the path before writing.

--- a/skills/authoring/create-draft/evals/evals.json
+++ b/skills/authoring/create-draft/evals/evals.json
@@ -1,0 +1,75 @@
+{
+  "skill_name": "docs-create-draft",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Draft a new page about configuring Fleet server TLS. Audience: operators with Elastic Stack experience. Purpose: walk through generating certs and applying them to Fleet server. Stack 9.0+, no serverless.",
+      "expected_output": "A how-to page with frontmatter (type: how-to, applies_to stack: ga 9.0+, serverless: unavailable), action-verb H1, Before you begin section, numbered steps, and a Related section.",
+      "expectations": [
+        "Classifies as how-to (not overview) because task is procedural",
+        "Frontmatter includes type: how-to",
+        "applies_to sets serverless: unavailable because Fleet Server is Stack-only",
+        "H1 uses action-verb pattern: 'Configure Fleet server TLS'",
+        "Includes a Before you begin section listing cert prerequisites",
+        "Steps are numbered, each step contains one instruction",
+        "Related section links to Fleet enrollment, TLS reference, or similar pages",
+        "Reading test subagent is invoked and its report is presented"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I want to write a page explaining what ES|QL is for a developer who has never used it. No issue, no target path yet.",
+      "expected_output": "Skill asks intake questions (audience, purpose, context, target location), classifies as overview, searches related docs, drafts with applies_to for both stack and serverless, runs reading test.",
+      "expectations": [
+        "Uses AskUserQuestion to gather audience, purpose, context, and target location before drafting",
+        "Classifies as overview (not how-to) because topic is conceptual",
+        "Frontmatter includes type: overview",
+        "applies_to covers both stack and serverless (ES|QL is available on both)",
+        "Searches Elastic docs MCP for existing ES|QL pages and reports duplication risk",
+        "Draft includes what ES|QL is, how it works, and why it matters",
+        "Related section links to ES|QL tutorials, how-tos, and reference pages",
+        "Reading test report flags any jargon that would confuse a new developer"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Draft a troubleshooting page for the error 'index_not_found_exception' in Elasticsearch. Audience: developers. Stack and serverless.",
+      "expected_output": "A troubleshooting page with a Symptoms section, a Resolution section, applies_to for both stack and serverless, and a problem-focused H1.",
+      "expectations": [
+        "Classifies as troubleshooting",
+        "H1 is problem-focused: 'index_not_found_exception errors' or similar",
+        "Includes Symptoms section with exact error message in monospace",
+        "Includes Resolution section with steps ordered most-common-fix first",
+        "Frontmatter type: troubleshooting",
+        "applies_to covers stack and serverless",
+        "Does not include a long conceptual explanation before the fix",
+        "Reading test subagent checks whether a reader in production crisis can find the fix quickly"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "There is already a page about Kibana alerting at https://www.elastic.co/docs/explore-analyze/alerts-cases/alerts. I want to add a new page about alert suppression. Should I create a new page or extend the existing one?",
+      "expected_output": "Skill checks docs coherence for alerting suppression, surfaces the existing alerts page, and surfaces the question to the user before drafting.",
+      "expectations": [
+        "Uses elastic-docs MCP search_docs or find_related_docs to discover existing alert suppression content",
+        "Surfaces any existing alert suppression coverage to the user",
+        "Asks the user whether to create a new page or extend the existing one before drafting",
+        "Does not draft without user confirmation when duplication risk is present"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "I have a GitHub issue at elastic/docs-content#9999 that asks to document the new --reindex-on-startup CLI flag for Elasticsearch. The feature ships in 9.5.",
+      "expected_output": "Skill fetches the issue, classifies the page as a how-to or reference, sets applies_to stack: ga 9.5+, serverless: unavailable (CLI flag is Stack-only), drafts the page, and runs the reading test.",
+      "expectations": [
+        "Runs gh issue view 9999 --repo elastic/docs-content",
+        "Extracts scope, audience, and applies_to hints from the issue",
+        "Classifies as how-to (procedural flag usage) or reference",
+        "applies_to sets stack: ga 9.5+",
+        "applies_to sets serverless: unavailable because CLI flags are Stack-only",
+        "Draft includes the flag name in monospace, its purpose, and a usage example",
+        "Reading test subagent is invoked with the classified audience from the issue"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `docs-create-draft`, a new authoring skill that guides the full lifecycle of drafting a new Elastic docs page from scratch.
- The skill auto-triggers when a user asks to write or document a new page and runs in a forked subagent context.
- Includes 5 eval test cases covering how-tos, overviews, troubleshooting, duplication risk, and GitHub issue intake.

## What the skill does

1. **Intake** — collects audience, purpose, GitHub/PR context, and target location via `AskUserQuestion`; fetches linked issues via the GitHub CLI; reads repo `toc.yml` and sibling files for conventions.
2. **Content type classification** — fetches live guidelines and templates from the Elastic Docs MCP; classifies among overview / how-to / tutorial / troubleshooting; falls back to free-form with explicit user notification when no type fits.
3. **Related-docs research** — uses `search_docs`, `find_related_docs`, and `check_docs_coherence` to find duplication risk and crosslink candidates.
4. **Frontmatter** — derives `applies_to`, `meta_title` (Pattern A/B), and `navigation_title` from context.
5. **Three-layer SEO title guidance** — page title, H1, and navigation title with length targets, content-type-specific patterns, and Pattern A/B page title rules.
6. **Light and full review checklists** — full review runs by default for new pages (user focus, technical accuracy, applicability, maintainability, language, style); light review available for small corrections.
7. **Subagent reading test** — spawns an `Agent` from the first-time reader's perspective and reports clarity gaps back to the user.

## Test plan

- [ ] Run `/docs-create-draft` with a topic description and verify intake questions appear
- [ ] Verify content type is classified and the correct template is fetched
- [ ] Verify `applies_to` and `meta_title` are generated correctly in frontmatter
- [ ] Verify the full review checklist runs and violations are fixed before the draft is presented
- [ ] Verify the reading test subagent is launched and its report is included in the output
- [ ] Verify the free-form fallback fires and notifies the user when no content type fits

🤖 Generated with [Claude Code](https://claude.com/claude-code)