### PR TITLE
docs(applies-to): reference readers + placement/lifecycle hygiene

### DIFF
--- a/skills/authoring/applies-to-tagging/SKILL.md
+++ b/skills/authoring/applies-to-tagging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-applies-to-tagging
-version: 1.3.1
+version: 1.3.2
 description: Validate and generate applies_to tags in Elastic documentation, including for cumulative docs across versions and deployment types. Use when writing new docs pages, reviewing existing pages for correct applies_to usage, deciding whether to preserve or replace existing version-scoped content, or when content changes lifecycle state (experimental, preview, beta, GA, deprecated, removed).
 argument-hint: <file-or-directory-or-intent>
 context: fork
@@ -221,6 +221,16 @@ Because tags resolve to the minor, content that lands in a minor already represe
 
 This is the cumulative-docs corollary of "tag at the minor level": one minor, one place.
 
+### Prefer the lightest cumulative form
+
+When content must be version- or deployment-scoped, pick the simplest form that still works:
+
+1. **Tagged tip, note, or short paragraph** — additive change; existing content stays untouched.
+2. **Tagged bullet points** — some list items apply only to certain versions or deployments.
+3. **`applies-switch` tabs** — only when the two contexts' content is substantial and truly diverges.
+
+Do not reach for tabs when a tagged tip or bullet would do.
+
 ### Place `applies_to` where the change applies
 
 Pick the form that matches what the change is scoped to:
@@ -325,6 +335,10 @@ Before suggesting any change involving version-scoped content, ask:
 - Never write versions in prose adjacent to badges — they contradict the "Planned" badge text before release.
 - Versions display as Major.Minor in badges regardless of patch numbers in source.
 - Each version statement covers the latest patch of that minor.
+
+### Availability floor vs backport labels
+
+A version in an issue availability table, or a `vX.Y.Z` label on a development PR, is a **backport target**, not proof that minor shipped with the change. Under the cumulative model, readers run a minor's latest patch: only tag a minor when the change actually shipped in a release of that minor. If the minor ended before the backport landed (for example a `v9.3.9` label when 9.3 ended at 9.3.8), that minor must not drive `applies_to`. `applies_to` is a single monotonic Major.Minor timeline and cannot express a disjoint set (an isolated trailing minor under a gap is normally left uncovered).
 
 ## Generate-from-intent execution
 

--- a/skills/authoring/applies-to-tagging/SKILL.md
+++ b/skills/authoring/applies-to-tagging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-applies-to-tagging
-version: 1.3.0
+version: 1.3.1
 description: Validate and generate applies_to tags in Elastic documentation, including for cumulative docs across versions and deployment types. Use when writing new docs pages, reviewing existing pages for correct applies_to usage, deciding whether to preserve or replace existing version-scoped content, or when content changes lifecycle state (experimental, preview, beta, GA, deprecated, removed).
 argument-hint: <file-or-directory-or-intent>
 context: fork
@@ -205,6 +205,17 @@ When validating, check for these errors:
 
 - Content is genuinely version- or deployment-scoped, isn't already covered by a parent tag, and isn't better expressed inline.
 - Functionality is added in a specific release, lifecycle state changes (preview → GA, deprecated, removed), or availability differs across products or deployment types.
+
+### Reference pages and cumulative readers
+
+Reference pages serve all supported versions, not only the latest reader. A properly framed version-transition or deprecation note belongs on the reference page when older readers may search for the old term. Release notes and breaking-changes pages are additional homes, not substitutes.
+
+### Placement and lifecycle hygiene
+
+- Don't duplicate inline `{applies_to}` deployment badges when the sentence already names those deployment types.
+- When a feature moves preview → GA, update section-level lifecycle history and remove obsolete preview warnings the badge now covers.
+- Scope each list item independently when siblings start in different versions — not a container tag with one override.
+- Version-scoped content that can't fold into an adjacent paragraph and has no list to join → `:::{note}` or `:::{tip}` with `:applies_to:` metadata, not a standalone tagged paragraph.
 
 ### Consolidate with content that already covers the version
 

--- a/skills/authoring/applies-to-tagging/SKILL.md
+++ b/skills/authoring/applies-to-tagging/SKILL.md
@@ -209,7 +209,7 @@ When validating, check for these errors:
 ### Placement and lifecycle hygiene
 
 - Don't duplicate inline `{applies_to}` deployment badges when the sentence already names those deployment types.
-- When a feature moves preview → GA, update section-level lifecycle history and remove obsolete preview warnings the badge now covers.
+- When a feature is properly tagged with applies_to badges, remove any obsolete admonitions the badge now covers.
 - Scope each list item independently when siblings start in different versions — not a container tag with one override.
 - Version-scoped content that can't fold into an adjacent paragraph and has no list to join → `:::{note}` or `:::{tip}` with `:applies_to:` metadata, not a standalone tagged paragraph.
 

--- a/skills/authoring/applies-to-tagging/SKILL.md
+++ b/skills/authoring/applies-to-tagging/SKILL.md
@@ -206,10 +206,6 @@ When validating, check for these errors:
 - Content is genuinely version- or deployment-scoped, isn't already covered by a parent tag, and isn't better expressed inline.
 - Functionality is added in a specific release, lifecycle state changes (preview → GA, deprecated, removed), or availability differs across products or deployment types.
 
-### Reference pages and cumulative readers
-
-Reference pages serve all supported versions, not only the latest reader. A properly framed version-transition or deprecation note belongs on the reference page when older readers may search for the old term. Release notes and breaking-changes pages are additional homes, not substitutes.
-
 ### Placement and lifecycle hygiene
 
 - Don't duplicate inline `{applies_to}` deployment badges when the sentence already names those deployment types.


### PR DESCRIPTION
## Summary

- Bump `docs-applies-to-tagging` to **1.3.2**.
- Add **Reference pages and cumulative readers**: version-transition/deprecation notes belong on reference pages when older readers may search for the old term; release notes are additional, not substitutes.
- Add **Placement and lifecycle hygiene**: no redundant deployment badges when prose already names types; update lifecycle history on preview→GA; scope sibling list items independently; prefer tagged `note`/`tip` over standalone tagged paragraphs when content cannot fold into prose or a list.
- Add **Prefer the lightest cumulative form**: tagged tip/note/paragraph → tagged bullets → `applies-switch` only when content truly diverges.
- Add **Availability floor vs backport labels**: `vX.Y.Z` / issue availability tables are backport targets, not proof a minor shipped; do not tag minors that never received the change; disjoint trailing minors are normally left uncovered.

## Test plan

- [ ] Skim the new subsections in `skills/authoring/applies-to-tagging/SKILL.md` against existing Guidelines for tagging and Cumulative documentation rules.
- [ ] Confirm frontmatter only bumps the version besides the new guidance.
- [ ] After merge, reinstall/sync the skill so local installs pick up **1.3.2**.