### PR TITLE
fix(review): require explicit invocation for review skills, clean template

### DIFF
--- a/skills/project/docs-draft-workflow-docs/SKILL.md
+++ b/skills/project/docs-draft-workflow-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-draft-workflow-docs
-version: 1.1.7
+version: 1.1.8
 description: Draft or update Elastic Workflows documentation pages in explore-analyze/workflows/ — step references, use cases, how-tos, concepts, and overviews. Use when writing Workflows docs, documenting a step type, turning workflow YAML into documentation, drafting from a doc issue in docs-content or docs-content-internal, or creating a new page under the Workflows docset.
 argument-hint: <doc-issue-url-or-page-idea-or-file-path>
 disable-model-invocation: true
@@ -390,7 +390,7 @@ Consult [`/docs-syntax-help`](https://github.com/elastic/elastic-docs-skills/tre
 ```yaml
 ---
 navigation_title: <Short nav label>   # omit on hub pages when title suffices
-description: <One sentence for search and tooltips — include "workflow" and the specific topic>
+description: <One sentence describing this Workflows page's content>
 products:
   - id: kibana
   - id: cloud-serverless    # include when feature is available on serverless

--- a/skills/review/check-contradictions/SKILL.md
+++ b/skills/review/check-contradictions/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: docs-check-contradictions
-version: 1.0.0
+version: 1.0.1
 description: Check whether newly written or updated documentation contradicts existing content elsewhere in the docs. Use when adding or editing any docs content — procedures, concepts, prerequisites, values, names, recommendations, or cross-references — to find stale or conflicting information, both in the local repo and across all published Elastic docs, that needs updating alongside your changes.
 argument-hint: <file-or-directory>
+disable-model-invocation: true
 context: fork
 allowed-tools: Read, Grep, Glob, WebFetch
 sources:

--- a/skills/review/docs-check-style/SKILL.md
+++ b/skills/review/docs-check-style/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: docs-check-style
-version: 1.2.0
+version: 1.2.1
 description: Check documentation for Elastic style guide compliance using Vale linter output and style rules. Use when writing, editing, or reviewing docs to catch voice, tone, grammar, formatting, accessibility, and word choice issues.
 argument-hint: <file-or-directory>
+disable-model-invocation: true
 context: fork
 allowed-tools: Read, Grep, Glob, Bash(vale *), CallMcpTool, WebFetch
 sources:

--- a/skills/review/flag-jargon-skill/SKILL.md
+++ b/skills/review/flag-jargon-skill/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: docs-flag-jargon-skill
-version: 1.0.2
+version: 1.0.3
 description: Flag Elastic-internal jargon in documentation and suggest plain-language replacements. Use when reviewing, writing, or editing docs to catch terms that external readers would not understand.
 argument-hint: <file-or-directory>
+disable-model-invocation: true
 context: fork
 allowed-tools: Read, Grep, Glob
 sources:

--- a/skills/review/frontmatter-audit/SKILL.md
+++ b/skills/review/frontmatter-audit/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: docs-frontmatter-audit
-version: 1.1.2
+version: 1.1.3
 description: Audit Elastic documentation files for frontmatter completeness and correctness. Checks products, description, and navigation_title fields across a directory. Use when auditing docs metadata, checking frontmatter quality before publishing, or validating a batch of files.
 argument-hint: <file-or-directory>
+disable-model-invocation: true
 context: fork
 allowed-tools: Read, Grep, Glob, CallMcpTool, WebFetch
 sources:


### PR DESCRIPTION
## Summary

- Add `disable-model-invocation: true` to four review skills (`docs-check-style`, `docs-flag-jargon-skill`, `docs-check-contradictions`, `docs-frontmatter-audit`) to prevent them from auto-triggering simultaneously on common editing tasks — each is a distinct review pass better invoked explicitly
- Simplify the verbose instruction-in-placeholder in the `docs-draft-workflow-docs` example frontmatter block

## Why

When all skills are installed, skills with overlapping trigger phrases like _"Use when writing, editing, or reviewing docs"_ compete with each other. A single review action could trigger all four review skills at once.

## Test plan

- [ ] Verify that `/docs-check-style`, `/docs-flag-jargon-skill`, `/docs-check-contradictions`, and `/docs-frontmatter-audit` still work when invoked explicitly
- [ ] Confirm that none of the four skills auto-trigger on a general editing task after reinstalling

🤖 Generated with [Claude Code](https://claude.com/claude-code)