### PR TITLE
Update changelog skills for notes command and versions field

### DIFF
--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-fix-changelog
-version: 2.6.1
+version: 2.6.2
 description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes type-title alignment, product/surface context for titles, description verb-tense (third-person present), and technical content assessment. Features repository-aware area validation and enhanced confidence scoring. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
 argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
 context: fork
@@ -78,6 +78,7 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 
 - **Scan for acronym definitions:** In PR titles/descriptions, look for patterns like "KI (Knowledge Indicator)" or context clues that define abbreviations
 - **Cross-reference expansions:** Before expanding acronyms, check if PR context contradicts assumed meaning
+- **Unknown shorthand:** For domain or Elastic-internal terms not in the Step 4 item 2 table, check `docs-flag-jargon-skill` patterns — flag and ask; do not guess expansions
 
 **Track for confidence:** Document what context was available (full PR details, partial info, URLs only, or none) and any fetch failures. This will inform confidence scoring in Step 7.
 
@@ -130,7 +131,7 @@ Apply the systematic pattern checklist from `docs-review-changelog` (Step 4). Ad
 - Add backticks around class/method names, config keys, API endpoints, or code identifiers where missing
 - Convert British spelling to US English: `serialise` → `serialize`, `colour` → `color`
 - Expand abbreviations where full form would be clearer: `params` → `parameters`
-- **Acronym expansion:** Follow the table above; flag domain acronyms as uncertain without PR context
+- **Acronym expansion:** Follow the table above; flag domain acronyms as uncertain without PR context. For internal shorthand not in this table, check `docs-flag-jargon-skill` patterns — flag and ask, do not guess
 - Standardize format: `ESQL` → `ES|QL`
 
 **3. Content quality fixes:**
@@ -226,60 +227,24 @@ Also check for formatting anti-patterns in existing `description`, `impact`, and
 
 **Character limits:** Target 80/600 characters; prefer clarity over trimming; split excess detail into `description` rather than shortening accurate titles. Suggest optional `description` when technical detail is stripped from the title.
 
-**Confidence tracking:** During suggestion generation, note factors that affect confidence:
+**Confidence rubric:** Apply High / Medium / Low to every suggestion.
 
-- **High confidence:** Routine pattern fixes (development prefixes, obvious YAML quoting), standard terminology, good PR context
-- **Medium confidence:** Technical terms with contextual clues, partial PR context, common Elastic terminology
-- **Low confidence:** Domain-specific terms without context, missing PR details, ambiguous phrasing that could have multiple interpretations, novel or uncommon technical concepts
+- **High:** Routine pattern (prefixes, YAML quoting), standard terms, full PR context, canonical guidance loaded
+- **Medium:** Partial PR context, mixed technical/user language, common Elastic terminology
+- **Low:** Missing PR details, domain terms without context, multiple valid interpretations — document both options
 
-**Type-Title Alignment Confidence:**
+**Topic mappings (use the rubric; do not restack High/Medium/Low lists):**
 
-- **High confidence type corrections:**
-  - Clear functional behavior (Fix broken → `bug-fix`)
-  - Clear new capability (Add substantial → `feature`)  
-  - PR context confirms the classification
-
-- **Medium confidence:**
-  - Performance improvements (could be `enhancement` or `bug-fix` depending on whether previous performance was "broken")
-  - Minor additions (could be `enhancement` or `feature` depending on scope)
-
-- **Low confidence - provide both options:**
-  - Ambiguous PR context about whether behavior was broken or just suboptimal
-  - Edge cases between types (e.g., "fixing" by adding a missing capability)
-
-**Technical Content Assessment Confidence:**
-
-- **High confidence user-impact rewrites:**
-  - Titles heavy in class names, method names, or implementation details without user context
-  - Multiple technical terms that don't explain user symptoms
-  - Clear implementation focus over user experience (e.g., "Fix splitValue nullability coercion when constructing ColorSeries")
-
-- **Medium confidence:**
-  - Technical terms mixed with some user-facing language
-  - Partial user context but still implementation-heavy
-
-- **Low priority formatting-only suggestions:**
-  - Titles already focused on user symptoms and impact
-  - Technical terms support rather than obscure user understanding
-  - Clear user-facing language with minimal technical jargon
-
-**Repository Validation Confidence:**
-
-- **High confidence:** Repository configuration loaded successfully, using authoritative area validation
-- **Medium confidence:** Repository config partially available or unclear
-- **Low confidence:** No repository configuration found, using generic validation rules
+- **Type-title:** High when PR confirms broken vs new capability; medium for performance or minor-add; low when both type and title could be right → emit Option A/B
+- **Technical content:** High for class/method-heavy titles; medium mixed; skip rewrite (formatting only) when the title is already user-facing
+- **Repository areas:** High if `docs/changelog.yml` loaded; low if not
+- **Feature prefix:** High for known UI/feature names; low if the colon phrase could be a technical term
 
 **Feature/app prefix integration patterns:**
 
 - `"[Feature]: Fix [issue]"` → `"Fix [issue] in [feature]"`
 - `"[Feature]: Enable [capability]"` → `"Enable [capability] for [feature]"`  
 - `"[Feature]: Add [functionality]"` → `"Add [functionality] to [feature]"`
-
-**Feature prefix suggestion confidence:**
-
-- **High confidence:** Clear UI component names, known Elastic features, good PR context
-- **Medium confidence:** Ambiguous feature names, partial context
-- **Low confidence:** Could be technical term vs feature name, missing PR details
 
 **Mode A & B** — for each weak or malformed field, show:
 
@@ -408,7 +373,7 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 
 ### Terminology uncertainties:
 - [Term/phrase]: Assumed [interpretation] — [Why uncertain, e.g., "Could be UI element vs feature name", "Missing domain context"]
-- [Acronym]: Expanded to "[expansion]" — [Confidence level: High/Medium/Low based on PR context, jargon-skill patterns, or domain knowledge]
+- [Acronym]: Expanded to "[expansion]" — [Confidence level: High/Medium/Low based on PR context, `docs-flag-jargon-skill` patterns, or domain knowledge]
 
 ### Assumptions made:
 - [Assumption]: [Rationale, e.g., "Normalized technical term based on common Elastic usage", "Inferred user impact from limited PR description"]
@@ -421,17 +386,7 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 - [✓/✗] PR/Issue context: [What was available or missing]
 ```
 
-**Confidence scoring guidance:**
-
-- **Low confidence triggers:** Missing PR context, ambiguous technical terms, conflicting pattern interpretations, failed resource fetches, domain-specific terminology without clear context
-- **Medium confidence:** Partial PR context, standard technical terms, routine pattern fixes with good guidance
-- **High confidence:** Full context available, canonical guidance loaded, routine formatting/structural fixes
-
-**Enhanced confidence methodology:**
-
-- **Document all uncertainties:** Explicitly flag each suggestion where multiple interpretations are possible
-- **Track assumption rationales:** Always explain why you chose one interpretation over another
-- **Resource dependency transparency:** Clearly indicate which suggestions depend on successfully loaded canonical guidance vs fallback patterns
+**Confidence scoring:** Use the Step 6 rubric. Document uncertainties, assumption rationales, and whether a suggestion depended on loaded canonical guidance vs fallback patterns.
 
 **Default behavior:** Default behavior is suggest-only. Only apply changes to disk after explicit user confirmation. After writing changes, re-parse YAML to validate the result.
 

--- a/skills/changelogs/fix-changelog/SKILL.md
+++ b/skills/changelogs/fix-changelog/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: docs-fix-changelog
-version: 2.5.0
+version: 2.6.1
 description: Suggest improved text for changelog YAML files against current Elastic standards. Mirrors the pattern catalog from docs-review-changelog to provide consistent fixes. Includes type-title alignment, product/surface context for titles, description verb-tense (third-person present), and technical content assessment. Features repository-aware area validation and enhanced confidence scoring. Supports single files or directories. Fetches canonical guidance to stay in sync. Use after review identifies quality issues, or when drafting new changelogs.
 argument-hint: "[changelog-file-or-directory] [pr/issue-context]"
 context: fork
 allowed-tools: Read, Grep, Glob, WebFetch
 sources:
 - https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs
+- https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ProductReference.cs
 - https://www.elastic.co/docs/contribute-docs/content-types/changelogs
 ---
 
-You are a changelog writing assistant for Elastic documentation. You suggest improved text for changelog fields and help draft content for new changelogs. You do not create files — file creation is always done via `docs-builder changelog add`.
+You are a changelog writing assistant for Elastic documentation. You suggest improved text for changelog fields and help draft content for new changelogs. You do not create files — file creation is always done via `docs-builder changelog add` (tied to a PR) or `docs-builder changelog note` (not tied to a PR).
 
 **Correctness priority:** Accuracy always takes precedence over style — never sacrifice factual correctness for better formatting or phrasing.
 
@@ -54,7 +55,7 @@ To ensure fix suggestions align with current standards and repository-specific r
 
 **Mode B — Process directory.** The first argument is a path to a directory containing changelog files. Process all `*.yaml` and `*.yml` files in that directory, suggesting improvements for each.
 
-**Mode C — Suggest content for a new file.** No file path is given, or the argument doesn't resolve to a readable file or directory. Suggest text for the text-based fields that the user can pass to `docs-builder changelog add`.
+**Mode C — Suggest content for a new file.** No file path is given, or the argument doesn't resolve to a readable file or directory. Suggest text for the text-based fields that the user can pass to `docs-builder changelog add` or `docs-builder changelog note`.
 
 Detect mode automatically: if the first argument resolves to a readable file, use Mode A. If it resolves to a directory, use Mode B. Otherwise, use Mode C.
 
@@ -82,8 +83,10 @@ Context from a PR or issue produces better suggestions. Use it in this order:
 
 **PR fetch and eligibility:**
 
+- Apply the same PR-linked vs version-listed rule as `docs-review-changelog` Step 3 (`note-*.yml` is a filename hint from `changelog note`, not a second content type)
 - When `prs` or `issues` URLs exist in the file, fetch them before suggesting — required, not optional
-- If PR/issue is test-only, refactor-only, or has no user-visible impact → recommend **delete file**, not a cosmetic rewrite
+- Version-listed files with neither `prs` nor `issues`: skip fetch (not a failure)
+- If a **PR-linked** changelog's PR/issue is test-only, refactor-only, or has no user-visible impact → recommend **delete file**, not a cosmetic rewrite (does not apply to version-listed files without a PR)
 - Directory mode: fetch PR context per file; skip auto-apply on low-confidence rewrites
 
 **Issue-title cross-check (when `issues` URLs are present and fetched successfully):**
@@ -205,6 +208,7 @@ Evaluate titles for implementation-focused language. Rewrite using `[Fix|Improve
 - `impact` / `action`: absent on `breaking-change`, `deprecation`, or `known-issue`; when present, use third-person present (same verb-form split as description)
 - `areas` if present: must be an array of strings; validate against repository configuration from Step 1 if available (only flag areas not in `docs/changelog.yml` pivot.areas section), otherwise use generic validation
 - `feature-id` if present: must be a string; no content quality check needed, just YAML type correctness
+- Schema (follow review Step 3 applicability): never suggest `products[].target` (obsolete — remove if present). Version-listed: require `products[].versions` as a YAML sequence. PR-linked: strip `versions`/`target` if present
 
 Also check for formatting anti-patterns in existing `description`, `impact`, and `action` values:
 
@@ -283,20 +287,19 @@ Also check for formatting anti-patterns in existing `description`, `impact`, and
 - One or two suggested alternatives
 - Brief explanation of what makes the suggestion better
 
-**Mode C** — suggest text for each relevant field, then present a ready-to-copy `docs-builder changelog add` command:
+**Mode C** — suggest text for each relevant field, then present a ready-to-copy command. If no PR (or a post-release `known-issue`/`security`), use `changelog note` with `|`-separated versions in `--products`. If PR-tied, use `changelog add` with **no** version in `--products`. Ask once if the path is unclear.
 
 ```sh
+# PR-linked — no version in --products
 docs-builder changelog add \
-  --type <type> \
-  --title "<suggested title>" \
-  --description "<suggested description>" \
-  --impact "<suggested impact>" \
-  --action "<suggested action>"
+  --type <type> --title "<title>" --products "elasticsearch ga" --prs <url-or-number>
+
+# Version-listed — versions in the products middle slot
+docs-builder changelog note \
+  --type known-issue --title "<title>" --products "elasticsearch 9.3.0|9.4.0 ga"
 ```
 
-Omit `--impact` and `--action` when not applicable to the type. Note that inside shell-quoted values, backticks must be escaped with a backslash (`\``) and double quotes must be escaped (`\"`).
-
-Remind the user that `--products`, `--prs`, `--issues`, and other non-text options must be provided separately. Refer them to `docs-builder changelog add --help` for the full list.
+Omit `--impact`/`--action` when not applicable. Escape backticks (`\``) and double quotes (`\"`) inside shell-quoted values. Refer to `changelog add --help` / `changelog note --help` for remaining flags.
 
 ### Enhanced Type-specific guidance
 
@@ -336,7 +339,7 @@ Remind the user that `--products`, `--prs`, `--issues`, and other non-text optio
 **`known-issue`:**
 
 - **Title pattern:** Describe the issue clearly, not the investigation
-- **Required fields:** Include all affected versions and contexts; describe any available workaround in `action`
+- **Required fields:** Put affected releases in `products[].versions` when not PR-linked; describe any available workaround in `action`. Use `changelog note` when there is no PR
 
 **`docs`:**
 
@@ -379,7 +382,7 @@ Use backticks for field names, parameter names, config keys, API endpoints, comm
 
 **Mode B:** Present results for each file processed in the directory. For files needing improvements, show "current → suggested" pairs. Summarize at the end with a count of files processed and files needing improvements. Do not apply changes without user confirmation.
 
-**Mode C:** Present the suggested field text, followed by the ready-to-copy `docs-builder changelog add` command. Invite the user to confirm or adjust before running the command. Make clear that the skill does not create the file — `changelog add` does.
+**Mode C:** Present the suggested field text, followed by the ready-to-copy `changelog add` or `changelog note` command. Invite the user to confirm or adjust before running the command. Make clear that the skill does not create the file — the CLI does.
 
 ### Confidence and assumptions section
 

--- a/skills/changelogs/fix-changelog/evals/evals.json
+++ b/skills/changelogs/fix-changelog/evals/evals.json
@@ -8,12 +8,12 @@
       "expectations": [
         "Suggests quoting 'Service Inventory' as UI element: \"Service Inventory\"",
         "Suggests capitalizing 'Machine Learning' as feature name (not quoting)",
-        "Includes article: 'the \"Service Inventory\" page'", 
+        "Includes article: 'the \"Service Inventory\" page'",
         "Explains UI vs feature name formatting distinction"
       ]
     },
     {
-      "id": 2, 
+      "id": 2,
       "prompt": "Fix this changelog where accuracy conflicts with style: Title 'Improve dashboard performance' but PR shows it actually fixes a memory leak bug that was causing crashes",
       "expected_output": "Suggestion prioritizes accuracy over style, recommending title change to reflect bug fix nature and possibly changing type to bug-fix",
       "expectations": [
@@ -54,7 +54,7 @@
       "expectations": [
         "Detects 'File upload:' as feature/app prefix pattern",
         "Suggests integrated alternative: 'Prevent data view creation in file upload tool without sufficient privileges'",
-        "Uses integration template: '[Feature]: Fix [issue]' → 'Fix [issue] in [feature]'",
+        "Uses integration template: '[Feature]: Fix [issue]' \u2192 'Fix [issue] in [feature]'",
         "Shows high confidence for clear UI component name",
         "Documents feature prefix suggestion in confidence section"
       ]
@@ -79,7 +79,7 @@
         "Suggests integration: 'Enable new authentication method for security'",
         "Shows medium confidence due to ambiguous feature name",
         "Documents ambiguity in feature prefix confidence section",
-        "Uses integration template: '[Feature]: Enable [capability]' → 'Enable [capability] for [feature]'"
+        "Uses integration template: '[Feature]: Enable [capability]' \u2192 'Enable [capability] for [feature]'"
       ]
     },
     {
@@ -185,12 +185,34 @@
     {
       "id": 17,
       "prompt": "Fix changelog: type bug-fix, title 'Fix Fleet secrets stored inline during package policy bulk create', description: 'Fixed Fleet package policy bulk creation so that secrets are stored in the secrets index (respecting the secrets storage setting) instead of inline on the package policy saved object.'",
-      "expected_output": "Rewrites description to third-person present Fixes…; explains title vs description verb-form split",
+      "expected_output": "Rewrites description to third-person present Fixes\u2026; explains title vs description verb-form split",
       "expectations": [
         "Suggests description starting with Fixes (not Fixed)",
         "References verb-form split: title base-form Fix; description third-person present Fixes",
         "Does not change title verb from Fix to Fixes",
         "High confidence for routine tense correction"
+      ]
+    },
+    {
+      "id": 18,
+      "prompt": "Mode C: Create a known-issue changelog for a post-release aggregations timeout affecting Elasticsearch 9.3.0 and 9.4.0. No associated PR.",
+      "expected_output": "Suggests docs-builder changelog note with pipe-separated versions in --products, not changelog add",
+      "expectations": [
+        "Emits changelog note command (not changelog add)",
+        "Uses | versions in --products middle slot (e.g. elasticsearch 9.3.0|9.4.0 ga)",
+        "Does not put a version in a changelog add --products flag",
+        "Type known-issue with title and optional issues citation guidance"
+      ]
+    },
+    {
+      "id": 19,
+      "prompt": "Fix existing PR-linked changelog 12345.yaml that still has products: [{product: elasticsearch, target: '9.3.0'}], prs present, title fine",
+      "expected_output": "Suggests removing obsolete products[].target; does not rewrite target to a new value",
+      "expectations": [
+        "Suggests removing products[].target (obsolete)",
+        "Does not suggest rewriting or replacing the target value",
+        "Does not suggest adding products[].versions on a PR-linked changelog",
+        "References review schema / never suggest target"
       ]
     }
   ]

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: docs-review-changelog
-version: 1.6.0
+version: 1.7.1
 description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, systematic pattern violations, type-title alignment mismatches, missing product/surface context in titles, description verb-tense issues, and overly technical content that needs user-focused rewrites. Features repository-aware area validation. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
 argument-hint: <file-or-directory>
 context: fork
 allowed-tools: Read, Grep, Glob, WebFetch
 sources:
   - https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ChangelogEntry.cs
+  - https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/ReleaseNotes/ProductReference.cs
   - https://www.elastic.co/docs/contribute-docs/content-types/changelogs
 ---
 <!-- Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
@@ -78,21 +79,30 @@ Glob for `*.yaml` and `*.yml` in `$ARGUMENTS`, or read a single file if given a 
 
 ## Step 3: Schema checks
 
-These are hard errors — structural/parse failures only (missing required fields, invalid enums, YAML types, unquoted scalars, required `impact`/`action` on `breaking-change`). Not style guidelines. The source of truth for the schema is `ChangelogEntry.cs` linked in `sources`.
+These are hard errors — structural/parse failures only (missing required fields, invalid enums, YAML types, unquoted scalars, required `impact`/`action` on `breaking-change`). Not style guidelines. The source of truth for the schema is `ChangelogEntry.cs` and `ProductReference.cs` linked in `sources`.
+
+One schema for all changelog YAML. Ask: **is this tied to a pull request?** A `note-*.yml` / `note-*.yaml` filename is only a hint that the file was written with `docs-builder changelog note`, not a second content type.
 
 **Required fields:**
 
 - `title`: must be present
 - `type`: must be present, value must be one of: `feature`, `enhancement`, `security`, `bug-fix`, `breaking-change`, `deprecation`, `known-issue`, `docs`, `regression`, `other`
-- `products`: must be present, non-empty array; each entry must have a `product` key
+- `products`: must be present, non-empty array; each product object must have a `product` key
 
 **Product ID validation:** Fetch `https://raw.githubusercontent.com/elastic/docs-builder/main/config/products.yml` to get the canonical list — valid IDs are the top-level keys under `products:`. If the fetch fails, flag unrecognized product IDs as "possibly invalid — could not verify against products.yml" rather than as errors.
 
+**Applicability (`prs` / `versions` / `target`):**
+
+- **PR-linked:** `prs` required (non-empty); `products[].versions` and `products[].target` forbidden
+- **Version-listed** (no PR, or `note-*.yml` filename hint): `products[].versions` required — YAML sequence of concrete versions/dates, not `*` or a `|` string; missing `prs`/`issues` is **not** an error; `products[].target` still forbidden
+- `products[].target` is obsolete on every file — schema error if present
+- File with `versions` and no `prs` on a PR-number filename: schema error — point writers to `docs-builder changelog note`
+
 **Optional field constraints:**
 
-- `products[n].lifecycle` if present on any product entry, fetch `https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/Lifecycle.cs` to get canonical list (such as `ga`)
-- `subtype`: only permitted on `breaking-change` entries; value must be one of: `api`, `behavioral`, `configuration`, `dependency`, `subscription`, `plugin`, `security`, `other`
-- `prs` and `issues`: optional arrays, may be empty or absent — no validation beyond YAML type correctness
+- `products[n].lifecycle` if present on any product object, fetch `https://github.com/elastic/docs-builder/blob/main/src/Elastic.Documentation/Lifecycle.cs` to get canonical list (such as `ga`)
+- `subtype`: only permitted on `breaking-change` changelogs; value must be one of: `api`, `behavioral`, `configuration`, `dependency`, `subscription`, `plugin`, `security`, `other`
+- `prs` and `issues`: arrays of strings when present (see applicability rules above for required vs optional)
 - `areas` if present: must be an array of strings — validate against repository configuration from Step 1 if available (only flag areas not in `docs/changelog.yml` pivot.areas section), otherwise use generic validation
 - `feature-id` if present: must be a string — used to associate a change with a unique feature flag
 - `highlight` if present: must be a boolean — marks entries for inclusion in release highlights

--- a/skills/changelogs/review-changelog/SKILL.md
+++ b/skills/changelogs/review-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-review-changelog
-version: 1.7.1
+version: 1.7.2
 description: Validate and assess the quality of Elastic changelog YAML files against current Elastic standards. Reports schema errors, content quality issues, systematic pattern violations, type-title alignment mismatches, missing product/surface context in titles, description verb-tense issues, and overly technical content that needs user-focused rewrites. Features repository-aware area validation. Fetches canonical guidance to stay in sync. Use when checking or reviewing changelog files before merging — pairs with docs-fix-changelog to get suggested fixes.
 argument-hint: <file-or-directory>
 context: fork
@@ -218,7 +218,7 @@ Flag overly technical titles that focus on implementation details rather than us
   - **Suggest:** Include user-facing symptoms or feature areas affected
 - **Preventive vs corrective:** On `bug-fix`/`regression`, if the title lacks symptom words (fail, error, crash, leak, hang, timeout, incorrect, missing, red, unallocated) and instead uses restriction words (allow, disallow, prevent, reject, validate, block), flag as likely preventive framing — soft heuristic for human review, not auto-fail
 - **Dev/test language:** Flag `Repro and fix` phrasing and PR-title passthrough with class/method names
-- **Unexpanded dev acronyms:** Flag `NPE`, `UOE` — expand per `docs-fix-changelog` acronym table
+- **Unexpanded dev acronyms:** Flag and expand per the `docs-fix-changelog` Step 4 item **2** table (do not copy the table here)
 - **ES|QL function tokens:** When `areas` includes `ES|QL`, flag unbackticked function names (`UNION_BY_NAME`, `JSON_EXTRACT`, etc.)
 
 **Eligibility (report only — never delete files):**

--- a/skills/changelogs/review-changelog/evals/evals.json
+++ b/skills/changelogs/review-changelog/evals/evals.json
@@ -1,5 +1,5 @@
 {
-  "skill_name": "docs-review-changelog", 
+  "skill_name": "docs-review-changelog",
   "evals": [
     {
       "id": 1,
@@ -14,11 +14,11 @@
     },
     {
       "id": 2,
-      "prompt": "Review changelog with Elastic context issues: title: 'Add support for ESQL queries in Observability' description: 'Enables ESQL functionality for monitoring use cases'", 
+      "prompt": "Review changelog with Elastic context issues: title: 'Add support for ESQL queries in Observability' description: 'Enables ESQL functionality for monitoring use cases'",
       "expected_output": "Applies Elastic software context to validate ES|QL terminology and Observability product reference",
       "expectations": [
         "Notes inconsistent 'ESQL' format (should be 'ES|QL')",
-        "Validates 'Observability' as legitimate Elastic product context", 
+        "Validates 'Observability' as legitimate Elastic product context",
         "Shows software context awareness in terminology checking",
         "Does not flag legitimate Elastic product references as marketing"
       ]
@@ -26,10 +26,10 @@
     {
       "id": 3,
       "prompt": "Review changelog when canonical guidance fails to load: title: 'Fix dashboard loading' with repository config not found",
-      "expected_output": "Includes confidence assessment showing failed resource loading and its impact on review accuracy", 
+      "expected_output": "Includes confidence assessment showing failed resource loading and its impact on review accuracy",
       "expectations": [
         "Includes 'Confidence Assessment' section in output",
-        "Shows '✗ Failed' status for canonical guidance or repository config", 
+        "Shows '\u2717 Failed' status for canonical guidance or repository config",
         "Notes 'Medium' or 'Low' validation confidence due to missing resources",
         "Explains review limitations due to resource loading failures"
       ]
@@ -75,7 +75,7 @@
         "Flags title does not start with approved base-form verb (noun phrase)",
         "Notes expected verbs for enhancement type (Improve, Update, Enable, etc.)",
         "Categorizes under quality warnings, not schema errors",
-        "Does not auto-fix — report only"
+        "Does not auto-fix \u2014 report only"
       ]
     },
     {
@@ -129,7 +129,7 @@
       "expectations": [
         "When areas includes ES|QL, flags unbackticked function token UNION_BY_NAME",
         "Includes Recommend removal subsection when PR is test-only/refactor-only",
-        "States review never deletes files — report only",
+        "States review never deletes files \u2014 report only",
         "Heuristic fires on test-only/internal refactor signals from PR or description"
       ]
     },
@@ -138,7 +138,7 @@
       "prompt": "Review changelog: type bug-fix, title 'Don't allow runtime fields to shadow fields used in index sort'",
       "expected_output": "Flags preventive/restrictive framing and negative imperative verb mismatch on bug-fix",
       "expectations": [
-        "Flags Don't as negative imperative — not an approved leading verb",
+        "Flags Don't as negative imperative \u2014 not an approved leading verb",
         "Flags preventive/restrictive framing: describes restriction not user-visible failure",
         "Suggests symptom-first rewrite pattern Fix [symptom] when [condition]",
         "Notes type-title alignment mismatch for bug-fix without Fix/Resolve/Correct",
@@ -153,7 +153,7 @@
         "Flags 'Ability to' as noun-phrase or gerund-led title pattern",
         "Notes title does not start with approved base-form verb for bug-fix (Fix, Resolve, Correct)",
         "Categorizes under quality warnings",
-        "Does not auto-fix — report only"
+        "Does not auto-fix \u2014 report only"
       ]
     },
     {
@@ -170,12 +170,34 @@
     {
       "id": 16,
       "prompt": "Review changelog: type bug-fix, title 'Fix Fleet secrets stored inline during package policy bulk create', description: 'Fixed Fleet package policy bulk creation so that secrets are stored in the secrets index (respecting the secrets storage setting) instead of inline on the package policy saved object.'",
-      "expected_output": "Flags past-tense description; notes third-person present standard (Fixes…)",
+      "expected_output": "Flags past-tense description; notes third-person present standard (Fixes\u2026)",
       "expectations": [
         "Flags past tense Fixed in description",
         "Notes verb-form split: titles use base-form (Fix); descriptions use third-person present (Fixes)",
-        "Expects Fixes Fleet package policy bulk creation…",
+        "Expects Fixes Fleet package policy bulk creation\u2026",
         "Reports under content quality / quality warnings"
+      ]
+    },
+    {
+      "id": 17,
+      "prompt": "Review PR-linked changelog 12345.yaml: products: [{product: elasticsearch, target: '9.3.0', versions: ['9.3.0']}], type: bug-fix, title: 'Fix query timeout', no prs field",
+      "expected_output": "Schema errors for obsolete target, forbidden versions on a PR-linked changelog, and missing required prs",
+      "expectations": [
+        "Flags products[].target as obsolete schema error (forbidden whether PR-linked or version-listed)",
+        "Flags products[].versions as forbidden on PR-linked changelogs",
+        "Flags missing/empty prs as schema error when tied to a PR",
+        "Does not treat target as a valid optional field"
+      ]
+    },
+    {
+      "id": 18,
+      "prompt": "Review note-aggregations-timeout.yml: type known-issue, title: 'Aggregations may time out on large clusters', products: [{product: elasticsearch, lifecycle: ga}], no prs, no versions",
+      "expected_output": "Schema error for missing products[].versions when not tied to a PR; missing prs is not an error",
+      "expectations": [
+        "Treats note-*.yml as a filename hint that the changelog is version-listed (not a second content type)",
+        "Flags missing/empty products[].versions as schema error when not tied to a PR",
+        "Does NOT flag absent prs as a schema error on version-listed changelogs",
+        "Reports under schema errors for versions only"
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/docs-builder/issues/3956

This PR updates `fix-changelog` and `review-changelog` skills for the recent changes to the `target` and `versions` fields in the changelog schema.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Cursor Grok 4.6


