### PR TITLE
Release skill refinement

### DIFF
--- a/skills/workflow/docs-stack-release/SKILL.md
+++ b/skills/workflow/docs-stack-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-stack-release
-version: 1.6.7
+version: 1.6.10
 description: >-
   Coordinate Elastic Stack docs releases: classify versions, route 8.x vs 9.x
   PRs, edit elastic/dev tracking issues, handle same-GA supersession, draft
@@ -212,13 +212,13 @@ Summarize the §0.2 stage, what is still blocking, and the **single** next actio
 
 - Semver list.
 - **Docs release issue(s)** -- `[Docs release] X.Y.Z`, not the eng release issue. `gh issue list -R elastic/dev --search "[Docs release] <version>" --json number,title,url`.
-- **Eng release issue** -- RC's parent (`[Release] X.Y.Z`, `X.Y.Z release`, etc.). Canonical schedule (FF, code freeze, GA), often links to docs issues, identifies the RC. Use for dates when the docs issue does not exist yet, which versions share a GA, and RC name.
+- **Eng release issue** -- RC's parent (`[Release] X.Y.Z`, `X.Y.Z release`, etc.). Canonical schedule (FF, GA), often links to docs issues, identifies the RC. Use for dates when the docs issue does not exist yet, which versions share a GA, and RC name.
 - If docs issues don't exist yet, §1.1.
 
 ### 1.1 Create docs release issues (when they don't exist)
 
 1. Template: 9.x minor → `docs-release.md`; 9.x patch → `docs-patch-release.md`; 8.x → `docs-patch-release-8.x.md`.
-2. Dates from the **eng release issue** (FF, code freeze, anticipated GA). If none, ask the user.
+2. Dates from the **eng release issue** (feature freeze, anticipated GA). If none, ask the user for those two only. **Merge release notes by** = the calendar day before anticipated GA (`[DAY_BEFORE_RELEASE_DATE]`). Do not ask for merge-by or code freeze.
 3. `gh issue create -R elastic/dev --template <template-file> --title "[Docs release] <version>"`
 4. Fill Overview (version, dates) and the **release coordinator** from the eng issue if listed. **Leave the rest of the template as-is** -- do not copy stakeholders from a previous release.
 5. Report: "Created #NNNN for X.Y.Z. Filled in dates from eng issue #MMMM. Please review."

--- a/skills/workflow/docs-stack-release/SKILL.md
+++ b/skills/workflow/docs-stack-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-stack-release
-version: 1.6.1
+version: 1.6.5
 description: >-
   Coordinate Elastic Stack docs releases: classify versions, route 8.x vs 9.x
   PRs, edit elastic/dev tracking issues, handle same-GA supersession, draft
@@ -38,7 +38,7 @@ allowed-tools: Read, Write, Glob, Bash(gh *), Bash(git *), CallMcpTool
 - Checklist is the step index. Live-fetch only open work. RN merge is not a checkbox -- always `gh pr view` blocking RN URLs.
 - A PR URL in the RN table is blocking until merged. Skip only `No changes` / `N/A`. Do not exempt Fleet, Agent, or any product by name.
 - Check boxes this skill just completed. Do not check anyone else's work (including docs-eng). Do not wait to be asked.
-- Slack: `<@USER_ID>` only; show a preview and confirm before send; thread follow-ups on the FF announcement. Read [slack-templates.md](./slack-templates.md) before drafting or sending.
+- Slack: read [slack-templates.md](./slack-templates.md) before drafting or sending. Confirm before send; thread follow-ups on the FF announcement.
 - Live/released Slack only after the **gate** (§0.3) and a user eyeball of the site. Do not draft before the gate.
 - Empty args / "how's my release": session state → active docs issue. Do not ask which version if one is in flight. After closed-issue cleanup leaves none, stop -- do not rediscover.
 - Cleanup = docs issue `CLOSED` only. 404 = drop that ID and rediscover. No TTL.
@@ -330,7 +330,7 @@ If the body is not already in context from §0, `gh issue view <N> -R elastic/de
 
 **Grouping:** 8.x and 9.x tables often differ -- separate "Ping for ..." sections when they do; merge duplicate product lines when the same stakeholders apply to multiple versions.
 
-Unresolved stakeholders: resolved in §0. If any remain at draft time, `[@handle]` and ask.
+Unresolved stakeholders and Slack send/preview: [slack-templates.md](./slack-templates.md).
 
 ### Templates, mentions, send
 
@@ -340,9 +340,9 @@ Read [slack-templates.md](./slack-templates.md) for templates, handle lookup, an
 
 **Send (do this even if you skip the templates file):**
 
-1. Show the exact message: "Here's what I'll post to `#docs`:\n[preview]\nSend?"
+1. Rendered preview and send rules: [slack-templates.md](./slack-templates.md). Then "Send?"
 2. Wait for confirmation. "Send it" / "looks good" counts. "Update the thread" / "check the boxes" does **not**.
-3. Mentions: `<@USER_ID>` only -- `@display` does not ping. Links: `<URL|text>` -- markdown `[text](url)` does not render.
+3. Payload mentions: `<@USER_ID>`. Never guess a `U…`.
 4. Follow-ups: thread on the FF announcement (`docsFfThreadTs`) **and** `reply_broadcast: true`.
 5. After send: check the matching docs-issue item (§4).
 

--- a/skills/workflow/docs-stack-release/SKILL.md
+++ b/skills/workflow/docs-stack-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-stack-release
-version: 1.6.5
+version: 1.6.7
 description: >-
   Coordinate Elastic Stack docs releases: classify versions, route 8.x vs 9.x
   PRs, edit elastic/dev tracking issues, handle same-GA supersession, draft
@@ -340,9 +340,9 @@ Read [slack-templates.md](./slack-templates.md) for templates, handle lookup, an
 
 **Send (do this even if you skip the templates file):**
 
-1. Rendered preview and send rules: [slack-templates.md](./slack-templates.md). Then "Send?"
+1. Preview in a fenced code block (slack-templates.md) so line breaks are preserved. Then "Send?"
 2. Wait for confirmation. "Send it" / "looks good" counts. "Update the thread" / "check the boxes" does **not**.
-3. Payload mentions: `<@USER_ID>`. Never guess a `U…`.
+3. Payload mentions: people `<@U…>`; user groups `<!subteam^S…>`. Never guess an ID.
 4. Follow-ups: thread on the FF announcement (`docsFfThreadTs`) **and** `reply_broadcast: true`.
 5. After send: check the matching docs-issue item (§4).
 

--- a/skills/workflow/docs-stack-release/slack-templates.md
+++ b/skills/workflow/docs-stack-release/slack-templates.md
@@ -26,9 +26,7 @@ Hi everyone! :wave: Today is the feature freeze for <VERSION>.
 
 <VERSION> is scheduled to release <ANTICIPATED_DATE>.
 
-Please add your release note PRs to the issue linked below:
-
-• <ISSUE_SLACK_LINK>
+Please add your release note PRs to the <ISSUE_URL|tracking issue>.
 
 (One `•` per product. Named: `@slack-name`. Placeholder: footnote person + assign phrasing above.)
 ```

--- a/skills/workflow/docs-stack-release/slack-templates.md
+++ b/skills/workflow/docs-stack-release/slack-templates.md
@@ -2,35 +2,38 @@
 
 Read this file before drafting or sending any Slack for the docs-stack-release skill. Fill placeholders from the docs issue (§6.1).
 
-## Handle resolution
+## Mentions, preview, send
 
-GitHub handle ≠ Slack handle. Never assume they are the same. Never invent people or Slack IDs.
+GitHub ≠ Slack. Never invent IDs. Appendix maps GitHub → Slack name (`@wajiha`), not a `U…`.
 
-1. Issue template / appendix lookup table first.
-2. Unmapped: `slack_search_users` (server: `user-slack`) by display name or real name.
-3. Confident match (exact display name or single result): use it. Uncertain: `[@handle]` and ask.
-4. **Always resolve to user IDs.** Messages must use `<@USER_ID>` (e.g. `<@U07EN8ZFRTL>`). Display names like `@wajiha` render as plain text and do not ping.
-5. **OOO before pinging.** For each resolved user, `slack_read_user_profile`. If status suggests unavailable (`:palm_tree:`, "OOO", "On vacation", "PTO", `:face_with_thermometer:`, `:no_entry:`): "Heads up: [name] appears to be out ([status]). Who should cover for them?" -- before drafting.
+- Look up every ping with `slack_search_users`. Cache in `slack.handles`. Ask only if search is empty or ambiguous.
+- User groups: copy `<@S…>` from the latest `#docs` freeze ping. Search will miss.
+- Placeholder row (`` `Beats point person` ``): ping the footnote GitHub person. RN: `please update the table to confirm who's responsible`. API docs / docs-eng: `who can assist with this release?`. Match the latest `#docs` freeze ping if it differs.
+- OOO: `slack_read_user_profile`. Flag palm_tree / OOO / PTO / sick. Not "in a meeting" or "outside of working hours".
 
-Batch-ask for any still-missing: "I need Slack equivalents for these handles: ..."
+**Preview:** rendered Slack. `@slack-name` from the appendix or profile (`@wajiha`, not `@Wajiha Parvez`). Links may be aliased (`<URL|text>`). Mentions must not: no `<@U…|Name>`, no full real names.
 
-## Formatting
+**Send:** `<@U…>` / `<@S…>` with no `|name` fallback. Confirm first ("send it" / "looks good"). Not on "update the thread". Follow-ups: thread on the FF ts + `reply_broadcast`. Then check the issue box.
 
-- **Mentions:** `<@USER_ID>`. Display names do not resolve.
-- **Links:** `<URL|display text>` (e.g. `<https://github.com/elastic/dev/issues/3600|tracking issue>`). Markdown `[text](url)` does not render.
-- **Bold / italic / strike:** `*bold*`, `_italic_`, `~text~` -- not `**bold**`.
+Format: `*bold*` `_italic_` `~strike~`. One `•` per product.
 
-## Send (always)
+## Feature freeze
 
-1. Draft from a template below.
-2. Show the user: "Here's what I'll post to `#docs`:\n[preview]\nSend?"
-3. Send only on confirmation ("send it" / "looks good" counts). Never send on "update the thread" or checkbox catch-up without a preview.
-4. Follow-ups (outstanding RNs, day-before, docs released): thread reply on the FF announcement **and** post to channel (`reply_broadcast: true`). Use `docsFfThreadTs` from session state if present; otherwise `slack_search_public` for the version in `#docs`, then persist the ts.
-5. After send: check the matching docs-issue checklist item (§4). Report: "Sent to #docs (threaded on the FF announcement). Checked [line] on #[issue]."
+**One version:** no `:bell: Ping for` line. Schedule line is `<VERSION> is scheduled to release <ANTICIPATED_DATE>.`
 
-## Feature freeze (multi-release)
+```markdown
+Hi everyone! :wave: Today is the feature freeze for <VERSION>.
 
-If all issues share one anticipated release date, use one date; otherwise list per version.
+<VERSION> is scheduled to release <ANTICIPATED_DATE>.
+
+Please add your release note PRs to the issue linked below:
+
+• <ISSUE_SLACK_LINK>
+
+(One `•` per product. Named: `@slack-name`. Placeholder: footnote person + assign phrasing above.)
+```
+
+**Multiple versions:** if they share one GA date, use one date; otherwise list per version. Keep a `:bell: Ping for` heading per group (8.x vs 9.x when tables differ).
 
 ```markdown
 Hi everyone! :wave: Today is the feature freeze for multiple releases.
@@ -39,20 +42,20 @@ The following releases are scheduled to release <ANTICIPATED_DATE>: <VERSION_LIS
 
 Please add your release note PRs to the issues linked below:
 
-**Releases & related issues**
+*Releases & related issues*
 
 (Repeat for each issue in the batch:)
 <VERSION> -- <ISSUE_SLACK_LINK>
 
 ---
 
-:bell: **Ping for <VERSION_OR_GROUP_A>**
+:bell: *Ping for <VERSION_OR_GROUP_A>*
 
-(One line per product with `<@USER_ID>` for stakeholders in the issue.)
+(One `•` per product.)
 
 ---
 
-:bell: **Ping for <VERSION_OR_GROUP_B>** *(repeat when 8.x vs 9.x tables differ)*
+:bell: *Ping for <VERSION_OR_GROUP_B>*
 ```
 
 ## Outstanding release notes (day before)
@@ -61,7 +64,7 @@ Please add your release note PRs to the issues linked below:
 The <VERSION_LIST> release is scheduled for tomorrow. The following release note PRs are still outstanding:
 
 (Repeat for each outstanding row:)
-• <Product> <@USER_ID>
+• <Product> @slack-name
 
 Please file and/or get approval on your PRs today. Tracking issue: <ISSUE_SLACK_LINK>
 ```

--- a/skills/workflow/docs-stack-release/slack-templates.md
+++ b/skills/workflow/docs-stack-release/slack-templates.md
@@ -7,13 +7,13 @@ Read this file before drafting or sending any Slack for the docs-stack-release s
 GitHub ≠ Slack. Never invent IDs. Appendix maps GitHub → Slack name (`@wajiha`), not a `U…`.
 
 - Look up every ping with `slack_search_users`. Cache in `slack.handles`. Ask only if search is empty or ambiguous.
-- User groups: copy `<@S…>` from the latest `#docs` freeze ping. Search will miss.
-- Placeholder row (`` `Beats point person` ``): ping the footnote GitHub person. RN: `please update the table to confirm who's responsible`. API docs / docs-eng: `who can assist with this release?`. Match the latest `#docs` freeze ping if it differs.
+- User groups: copy the `S…` ID from the latest `#docs` freeze ping. Search will miss. Send as `<!subteam^S…>` -- `<@S…>` is how search displays a group and will not ping.
+- Placeholder row (`` `Beats point person` ``): ping **only** the footnote GitHub person on the current issue. Do not add extra people from an older freeze ping. RN: `please update the table to confirm who's responsible`. API docs / docs-eng: `who can assist with this release?`. Match the latest `#docs` freeze ping for **phrasing** only.
 - OOO: `slack_read_user_profile`. Flag palm_tree / OOO / PTO / sick. Not "in a meeting" or "outside of working hours".
 
-**Preview:** rendered Slack. `@slack-name` from the appendix or profile (`@wajiha`, not `@Wajiha Parvez`). Links may be aliased (`<URL|text>`). Mentions must not: no `<@U…|Name>`, no full real names.
+**Preview:** the exact Slack draft in a fenced code block so every line break is visible. Do not render it as chat markdown -- that collapses the message onto one line. `@slack-name` from the appendix or profile (`@wajiha`, not `@Wajiha Parvez`). Links may be aliased (`<URL|text>`). Mentions must not: no `<@U…|Name>`, no full real names.
 
-**Send:** `<@U…>` / `<@S…>` with no `|name` fallback. Confirm first ("send it" / "looks good"). Not on "update the thread". Follow-ups: thread on the FF ts + `reply_broadcast`. Then check the issue box.
+**Send:** people `<@U…>`; user groups `<!subteam^S…>`. No `|name` fallback. Confirm first ("send it" / "looks good"). Not on "update the thread". Follow-ups: thread on the FF ts + `reply_broadcast`. Then check the issue box.
 
 Format: `*bold*` `_italic_` `~strike~`. One `•` per product.
 


### PR DESCRIPTION
A couple of small tweaks I found when trying to do a presentation:

 * slack previews were inscrutable because the skill showed slack ids, not usernames
 * it was asking for a date that's relevant to eng only
 * some optimization of slack templates for single-release messages